### PR TITLE
linux opennlp command to add all jars in lib folder to classpath 

### DIFF
--- a/opennlp-distr/src/main/bin/opennlp
+++ b/opennlp-distr/src/main/bin/opennlp
@@ -32,4 +32,4 @@ fi
 # Might fail if $0 is a link
 OPENNLP_HOME=`dirname "$0"`/..
 
-$JAVACMD -Xmx1024m -jar $OPENNLP_HOME/lib/opennlp-tools-*.jar $@
+$JAVACMD -Xmx4024m -cp $(echo $OPENNLP_HOME/lib/*.jar | tr ' ' ':') opennlp.tools.cmdline.CLI $@

--- a/opennlp-distr/src/main/bin/opennlp
+++ b/opennlp-distr/src/main/bin/opennlp
@@ -32,4 +32,4 @@ fi
 # Might fail if $0 is a link
 OPENNLP_HOME=`dirname "$0"`/..
 
-$JAVACMD -Xmx4024m -cp $(echo $OPENNLP_HOME/lib/*.jar | tr ' ' ':') opennlp.tools.cmdline.CLI $@
+$JAVACMD -Xmx1024m -cp $(echo $OPENNLP_HOME/lib/*.jar | tr ' ' ':') opennlp.tools.cmdline.CLI $@


### PR DESCRIPTION
opennlp command did not load my jar containing some custom feature generators even though I placed it in the lib folder.

trunk: 
$JAVACMD -Xmx1024m -jar $OPENNLP_HOME/lib/opennlp-tools-*.jar $@
will not load any other jars.

I made a patch that loads alle the *.jars in lib.

br
Peter
