### PR TITLE
OPENNLP-274: Adds cache to Chunker

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkerFactory.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkerFactory.java
@@ -60,4 +60,8 @@ public class ChunkerFactory extends BaseToolFactory {
   public ChunkerContextGenerator getContextGenerator() {
     return new DefaultChunkerContextGenerator();
   }
+
+  public ChunkerContextGenerator getContextGenerator(int cache) {
+    return new DefaultChunkerContextGenerator(cache);
+  }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkerME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkerME.java
@@ -94,7 +94,7 @@ public class ChunkerME implements Chunker {
   @Deprecated
   private ChunkerME(ChunkerModel model, int beamSize) {
 
-   contextGenerator = model.getFactory().getContextGenerator();
+   contextGenerator = model.getFactory().getContextGenerator(beamSize);
    sequenceValidator = model.getFactory().getSequenceValidator();
 
     if (model.getChunkerSequenceModel() != null) {
@@ -177,7 +177,7 @@ public class ChunkerME implements Chunker {
     SequenceClassificationModel<String> seqChunkerModel = null;
 
     if (TrainerType.EVENT_MODEL_TRAINER.equals(trainerType)) {
-      ObjectStream<Event> es = new ChunkerEventStream(in, factory.getContextGenerator());
+      ObjectStream<Event> es = new ChunkerEventStream(in, factory.getContextGenerator(beamSize));
       EventTrainer trainer = TrainerFactory.getEventTrainer(mlParams.getSettings(),
           manifestInfoEntries);
       chunkerModel = trainer.train(es);
@@ -188,7 +188,7 @@ public class ChunkerME implements Chunker {
 
       // TODO: This will probably cause issue, since the feature generator uses the outcomes array
 
-      ChunkSampleSequenceStream ss = new ChunkSampleSequenceStream(in, factory.getContextGenerator());
+      ChunkSampleSequenceStream ss = new ChunkSampleSequenceStream(in, factory.getContextGenerator(beamSize));
       seqChunkerModel = trainer.train(ss);
     }
     else {


### PR DESCRIPTION
Adds cache to Chunker. Tested and it causes no regression.
Also tested if there is any improvement adding the cache, but did not notice. Comparing Chunker CV in 1.7.0 and 1.7.1-SNAPSHOT witch cache 3 and 1000, there was no relevant improvement in speed.

See issue OPENNLP-274