### PR TITLE
OPENNLP-928: Deprecate old UIMA trainers and some utils

### DIFF
--- a/opennlp-uima/src/main/java/opennlp/uima/chunker/ChunkerTrainer.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/chunker/ChunkerTrainer.java
@@ -63,7 +63,10 @@ import org.apache.uima.util.ProcessTrace;
  *   <tr><td>String</td> <td>opennlp.uima.ChunkType</td></tr>
  *   <tr><td>String</td> <td>opennlp.uima.ChunkTagFeature</td></tr>
  * </table>
+ *
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
 public class ChunkerTrainer extends CasConsumer_ImplBase {
 
   private List<ChunkSample> mChunkSamples = new ArrayList<>();

--- a/opennlp-uima/src/main/java/opennlp/uima/doccat/DocumentCategorizerTrainer.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/doccat/DocumentCategorizerTrainer.java
@@ -51,7 +51,11 @@ import org.apache.uima.util.ProcessTrace;
  * OpenNLP NameFinder trainer.
  *
  * Note: This class is still work in progress, and should not be used!
+ *
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
+
 public class DocumentCategorizerTrainer extends CasConsumer_ImplBase {
 
   private UimaContext mContext;

--- a/opennlp-uima/src/main/java/opennlp/uima/namefind/NameFinderTrainer.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/namefind/NameFinderTrainer.java
@@ -97,7 +97,11 @@ import opennlp.uima.util.UimaUtil;
  *   <td>Encoding of the sample trace file</td></tr>
  * </table>
  * <p>
+ *
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
+
 public final class NameFinderTrainer extends CasConsumer_ImplBase {
 
   private static final String FEATURE_GENERATOR_DEFINITION_FILE_PARAMETER =

--- a/opennlp-uima/src/main/java/opennlp/uima/postag/POSTaggerTrainer.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/postag/POSTaggerTrainer.java
@@ -64,7 +64,11 @@ import org.apache.uima.util.ProcessTrace;
  *       the feature must be of type String</td></tr>
  *   <tr><td>String</td> <td>opennlp.uima.TagDictionaryName</td></tr>
  * </table>
+ *
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
+
 public class POSTaggerTrainer extends CasConsumer_ImplBase {
 
   public static final String TAG_DICTIONARY_NAME = "opennlp.uima.TagDictionaryName";

--- a/opennlp-uima/src/main/java/opennlp/uima/sentdetect/SentenceDetectorTrainer.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/sentdetect/SentenceDetectorTrainer.java
@@ -65,7 +65,10 @@ import org.apache.uima.util.ProcessTrace;
  *   <tr><td>String</td> <td>opennlp.uima.EOSChars</td>
  *   <td>A string containing end-of-sentence characters</td></tr>
  * </table>
+ *
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
 public final class SentenceDetectorTrainer extends CasConsumer_ImplBase {
 
   private List<SentenceSample> sentenceSamples = new ArrayList<>();

--- a/opennlp-uima/src/main/java/opennlp/uima/tokenize/TokenizerTrainer.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/tokenize/TokenizerTrainer.java
@@ -78,7 +78,11 @@ import org.apache.uima.util.ProcessTrace;
  *   <tr><th>Type</th> <th>Name</th> <th>Description</th></tr>
  *   <tr><td>Boolean</td> <td>opennlp.uima.tokenizer.IsSkipAlphaNumerics</td></tr>
  * </table>
+ *
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
+
 public final class TokenizerTrainer extends CasConsumer_ImplBase {
 
   private static final String IS_ALPHA_NUMERIC_OPTIMIZATION =

--- a/opennlp-uima/src/main/java/opennlp/uima/util/CasConsumerUtil.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/util/CasConsumerUtil.java
@@ -34,7 +34,10 @@ import org.apache.uima.util.Logger;
 
 /**
  * This is a util class for cas consumer.
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
+
 public final class CasConsumerUtil {
 
   private CasConsumerUtil(){

--- a/opennlp-uima/src/main/java/opennlp/uima/util/SampleTraceStream.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/util/SampleTraceStream.java
@@ -28,7 +28,10 @@ import opennlp.tools.util.ObjectStream;
  * In the case the underlying stream is reseted this stream will
  * detect that, and does not write the samples again to the output writer.
  * @param <T>
+ *
+ * @deprecated will be removed after 1.7.1 release, there is no replacement
  */
+@Deprecated
 public class SampleTraceStream<T> extends FilterObjectStream<T, T> {
 
   private final Writer out;


### PR DESCRIPTION
The deprecated utils are only used by the trainers and have
no other purpose, they should be removed as well.