### PR TITLE
OPENNLP-958: improved NameFinder resource manager

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderTrainerTool.java
@@ -24,6 +24,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.w3c.dom.Element;
 
@@ -46,6 +49,8 @@ import opennlp.tools.util.model.ModelUtil;
 
 public final class TokenNameFinderTrainerTool
     extends AbstractTrainerTool<NameSample, TrainerToolParams> {
+
+  private static final Pattern EXTENSION_PATTERN = Pattern.compile(".*\\.([^\\.]*)$");
 
   interface TrainerToolParams extends TrainingParams, TrainingToolParams {
 
@@ -121,23 +126,35 @@ public final class TokenNameFinderTrainerTool
 
       for (File resourceFile : resourceFiles) {
         String resourceName = resourceFile.getName();
-        //gettting the serializer key from the element tag name
-        //if the element contains a dict attribute
+
+        // if the element contains a dict attribute we try gettting
+        // the serializer key from the element tag name
         for (Element xmlElement : elements) {
           String dictName = xmlElement.getAttribute("dict");
           if (dictName != null && dictName.equals(resourceName)) {
             serializer = artifactSerializers.get(xmlElement.getTagName());
           }
         }
-        // TODO: Do different? For now just ignore ....
-        if (serializer == null)
-          continue;
+
+        // otherwise we use the extension
+        if (Objects.isNull(serializer)) {
+          Matcher matcher = EXTENSION_PATTERN.matcher(resourceName);
+          if (matcher.matches()) {
+            String resourceExtension = matcher.group(1);
+            serializer = artifactSerializers.get(resourceExtension);
+            if (Objects.isNull(serializer)) {
+              throw new TerminateToolException(-1,
+                  "Unable to find a serializer for extension: " + resourceExtension);
+            }
+          } else {
+            throw new TerminateToolException(-1, "Unable to get file extension: " + resourceName);
+          }
+        }
 
         try (InputStream resourceIn = CmdLineUtil.openInFile(resourceFile)) {
           resources.put(resourceName, serializer.create(resourceIn));
         } catch (IOException e) {
-          // TODO: Fix exception handling
-          e.printStackTrace();
+          throw new TerminateToolException(-1, "Exception loading resource: " + resourceName, e);
         }
       }
     }

--- a/opennlp-tools/src/main/java/opennlp/tools/namefind/TokenNameFinderModel.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/namefind/TokenNameFinderModel.java
@@ -209,6 +209,7 @@ public class TokenNameFinderModel extends BaseModel {
     Map<String, ArtifactSerializer> serializers = BaseModel.createArtifactSerializers();
 
     serializers.put("featuregen", new ByteArraySerializer());
+    serializers.put("bin", new ByteArraySerializer());
     serializers.put("wordcluster", new WordClusterDictionary.WordClusterDictionarySerializer());
     serializers.put("brownclustertoken", new BrownCluster.BrownClusterSerializer());
     serializers.put("brownclustertokenclass", new BrownCluster.BrownClusterSerializer());


### PR DESCRIPTION
The prevous version was not handling errors properly. Also, it could only load dictionaries. Now it can load resources based on its extension.