### PR TITLE
OPENNLP-944: Add correction param and const back to GIS reader/writer

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/GISModelReader.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/GISModelReader.java
@@ -65,6 +65,13 @@ public class GISModelReader extends AbstractModelReader {
    *         GISModelReader (usually via its the constructor).
    */
   public AbstractModel constructModel() throws IOException {
+
+    // read correction constant (not used anymore)
+    readInt();
+
+    // read correction params (not used anymore)
+    readDouble();
+
     String[] outcomeLabels = getOutcomes();
     int[][] outcomePatterns = getOutcomePatterns();
     String[] predLabels = getPredicates();
@@ -78,5 +85,4 @@ public class GISModelReader extends AbstractModelReader {
       System.out.println("Error: attempting to load a " + modelType
           + " model as a GIS model." + " You should expect problems.");
   }
-
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/GISModelWriter.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/GISModelWriter.java
@@ -68,6 +68,12 @@ public abstract class GISModelWriter extends AbstractModelWriter {
     // the type of model (GIS)
     writeUTF("GIS");
 
+    // the value of the correction constant (not used anymore)
+    writeInt(1);
+
+    // the value of the correction params (not used anymore)
+    writeDouble(1);
+
     // the mapping from outcomes to their integer indexes
     writeInt(OUTCOME_LABELS.length);
 


### PR DESCRIPTION
The two parameters need still to be written and read to maintain
backward compatibility with older models and 1.7.0 and 1.7.1.