### PR TITLE
OpenNLP-977 Remove deprecated map methods

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkerME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkerME.java
@@ -171,7 +171,7 @@ public class ChunkerME implements Chunker {
 
     Map<String, String> manifestInfoEntries = new HashMap<>();
 
-    TrainerType trainerType = TrainerFactory.getTrainerType(mlParams.getSettings());
+    TrainerType trainerType = TrainerFactory.getTrainerType(mlParams);
 
 
     MaxentModel chunkerModel = null;
@@ -179,13 +179,13 @@ public class ChunkerME implements Chunker {
 
     if (TrainerType.EVENT_MODEL_TRAINER.equals(trainerType)) {
       ObjectStream<Event> es = new ChunkerEventStream(in, factory.getContextGenerator());
-      EventTrainer trainer = TrainerFactory.getEventTrainer(mlParams.getSettings(),
+      EventTrainer trainer = TrainerFactory.getEventTrainer(mlParams,
           manifestInfoEntries);
       chunkerModel = trainer.train(es);
     }
     else if (TrainerType.SEQUENCE_TRAINER.equals(trainerType)) {
       SequenceTrainer trainer = TrainerFactory.getSequenceModelTrainer(
-          mlParams.getSettings(), manifestInfoEntries);
+          mlParams, manifestInfoEntries);
 
       // TODO: This will probably cause issue, since the feature generator uses the outcomes array
 

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/CmdLineUtil.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/CmdLineUtil.java
@@ -324,11 +324,11 @@ public final class CmdLineUtil {
         throw new TerminateToolException(-1, "Error during parameters loading: " + e.getMessage(), e);
       }
 
-      if (!TrainerFactory.isValid(params.getSettings())) {
+      if (!TrainerFactory.isValid(params)) {
         throw new TerminateToolException(1, "Training parameters file '" + paramFile + "' is invalid!");
       }
 
-      TrainerFactory.TrainerType trainerType = TrainerFactory.getTrainerType(params.getSettings());
+      TrainerFactory.TrainerType trainerType = TrainerFactory.getTrainerType(params);
 
       if (!supportSequenceTraining
           && trainerType.equals(TrainerFactory.TrainerType.EVENT_MODEL_SEQUENCE_TRAINER)) {

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserTrainerTool.java
@@ -120,23 +120,23 @@ public final class ParserTrainerTool extends AbstractTrainerTool<Parse, TrainerT
     mlParams = CmdLineUtil.loadTrainingParameters(params.getParams(), true);
 
     if (mlParams != null) {
-      if (!TrainerFactory.isValid(mlParams.getSettings("build"))) {
+      if (!TrainerFactory.isValid(mlParams.getParameters("build"))) {
         throw new TerminateToolException(1, "Build training parameters are invalid!");
       }
 
-      if (!TrainerFactory.isValid(mlParams.getSettings("check"))) {
+      if (!TrainerFactory.isValid(mlParams.getParameters("check"))) {
         throw new TerminateToolException(1, "Check training parameters are invalid!");
       }
 
-      if (!TrainerFactory.isValid(mlParams.getSettings("attach"))) {
+      if (!TrainerFactory.isValid(mlParams.getParameters("attach"))) {
         throw new TerminateToolException(1, "Attach training parameters are invalid!");
       }
 
-      if (!TrainerFactory.isValid(mlParams.getSettings("tagger"))) {
+      if (!TrainerFactory.isValid(mlParams.getParameters("tagger"))) {
         throw new TerminateToolException(1, "Tagger training parameters are invalid!");
       }
 
-      if (!TrainerFactory.isValid(mlParams.getSettings("chunker"))) {
+      if (!TrainerFactory.isValid(mlParams.getParameters("chunker"))) {
         throw new TerminateToolException(1, "Chunker training parameters are invalid!");
       }
     }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerTrainerTool.java
@@ -56,7 +56,7 @@ public final class POSTaggerTrainerTool
     super.run(format, args);
 
     mlParams = CmdLineUtil.loadTrainingParameters(params.getParams(), true);
-    if (mlParams != null && !TrainerFactory.isValid(mlParams.getSettings())) {
+    if (mlParams != null && !TrainerFactory.isValid(mlParams)) {
       throw new TerminateToolException(1, "Training parameters file '" + params.getParams() +
           "' is invalid!");
     }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorTrainerTool.java
@@ -65,7 +65,7 @@ public final class SentenceDetectorTrainerTool
     mlParams = CmdLineUtil.loadTrainingParameters(params.getParams(), false);
 
     if (mlParams != null) {
-      if (!TrainerType.EVENT_MODEL_TRAINER.equals(TrainerFactory.getTrainerType(mlParams.getSettings()))) {
+      if (!TrainerType.EVENT_MODEL_TRAINER.equals(TrainerFactory.getTrainerType(mlParams))) {
         throw new TerminateToolException(1, "Sequence training is not supported!");
       }
     }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerTool.java
@@ -63,12 +63,12 @@ public final class TokenizerTrainerTool
     mlParams = CmdLineUtil.loadTrainingParameters(params.getParams(), false);
 
     if (mlParams != null) {
-      if (!TrainerFactory.isValid(mlParams.getSettings())) {
+      if (!TrainerFactory.isValid(mlParams)) {
         throw new TerminateToolException(1, "Training parameters file '" + params.getParams() +
             "' is invalid!");
       }
 
-      if (!TrainerType.EVENT_MODEL_TRAINER.equals(TrainerFactory.getTrainerType(mlParams.getSettings()))) {
+      if (!TrainerType.EVENT_MODEL_TRAINER.equals(TrainerFactory.getTrainerType(mlParams))) {
         throw new TerminateToolException(1, "Sequence training is not supported!");
       }
     }

--- a/opennlp-tools/src/main/java/opennlp/tools/doccat/DocumentCategorizerME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/doccat/DocumentCategorizerME.java
@@ -236,7 +236,7 @@ public class DocumentCategorizerME implements DocumentCategorizer {
     Map<String, String> manifestInfoEntries = new HashMap<>();
 
     EventTrainer trainer = TrainerFactory.getEventTrainer(
-        mlParams.getSettings(), manifestInfoEntries);
+        mlParams, manifestInfoEntries);
 
     MaxentModel model = trainer.train(
         new DocumentCategorizerEventStream(samples, factory.getFeatureGenerators()));

--- a/opennlp-tools/src/main/java/opennlp/tools/lemmatizer/LemmatizerME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/lemmatizer/LemmatizerME.java
@@ -157,26 +157,26 @@ public class LemmatizerME implements Lemmatizer {
 
     Map<String, String> manifestInfoEntries = new HashMap<>();
 
-    TrainerType trainerType = TrainerFactory.getTrainerType(trainParams.getSettings());
+    TrainerType trainerType = TrainerFactory.getTrainerType(trainParams);
 
     MaxentModel lemmatizerModel = null;
     SequenceClassificationModel<String> seqLemmatizerModel = null;
     if (TrainerType.EVENT_MODEL_TRAINER.equals(trainerType)) {
       ObjectStream<Event> es = new LemmaSampleEventStream(samples, contextGenerator);
 
-      EventTrainer trainer = TrainerFactory.getEventTrainer(trainParams.getSettings(),
+      EventTrainer trainer = TrainerFactory.getEventTrainer(trainParams,
           manifestInfoEntries);
       lemmatizerModel = trainer.train(es);
     }
     else if (TrainerType.EVENT_MODEL_SEQUENCE_TRAINER.equals(trainerType)) {
       LemmaSampleSequenceStream ss = new LemmaSampleSequenceStream(samples, contextGenerator);
       EventModelSequenceTrainer trainer =
-          TrainerFactory.getEventModelSequenceTrainer(trainParams.getSettings(), manifestInfoEntries);
+          TrainerFactory.getEventModelSequenceTrainer(trainParams, manifestInfoEntries);
       lemmatizerModel = trainer.train(ss);
     }
     else if (TrainerType.SEQUENCE_TRAINER.equals(trainerType)) {
       SequenceTrainer trainer = TrainerFactory.getSequenceModelTrainer(
-          trainParams.getSettings(), manifestInfoEntries);
+          trainParams, manifestInfoEntries);
 
       // TODO: This will probably cause issue, since the feature generator uses the outcomes array
 

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/EventModelSequenceTrainer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/EventModelSequenceTrainer.java
@@ -22,12 +22,15 @@ import java.util.Map;
 
 import opennlp.tools.ml.model.MaxentModel;
 import opennlp.tools.ml.model.SequenceStream;
+import opennlp.tools.util.TrainingParameters;
 
 public interface EventModelSequenceTrainer {
 
   String SEQUENCE_VALUE = "EventModelSequence";
 
+  @Deprecated
   void init(Map<String, String> trainParams, Map<String, String> reportMap);
+  void init(TrainingParameters trainParams, Map<String, String> reportMap);
 
   MaxentModel train(SequenceStream events) throws IOException;
 

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/EventTrainer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/EventTrainer.java
@@ -24,12 +24,15 @@ import opennlp.tools.ml.model.DataIndexer;
 import opennlp.tools.ml.model.Event;
 import opennlp.tools.ml.model.MaxentModel;
 import opennlp.tools.util.ObjectStream;
+import opennlp.tools.util.TrainingParameters;
 
 public interface EventTrainer {
 
   String EVENT_VALUE = "Event";
 
+  @Deprecated
   void init(Map<String, String> trainParams, Map<String, String> reportMap);
+  void init(TrainingParameters trainingParams, Map<String, String> reportMap);
 
   MaxentModel train(ObjectStream<Event> events) throws IOException;
   MaxentModel train(DataIndexer indexer) throws IOException;

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/SequenceTrainer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/SequenceTrainer.java
@@ -22,12 +22,15 @@ import java.util.Map;
 
 import opennlp.tools.ml.model.SequenceClassificationModel;
 import opennlp.tools.ml.model.SequenceStream;
+import opennlp.tools.util.TrainingParameters;
 
 public interface SequenceTrainer {
 
   String SEQUENCE_VALUE = "Sequence";
 
+  @Deprecated
   void init(Map<String, String> trainParams, Map<String, String> reportMap);
+  void init(TrainingParameters trainParams, Map<String, String> reportMap);
 
   SequenceClassificationModel<String> train(SequenceStream events) throws IOException;
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/namefind/NameFinderME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/namefind/NameFinderME.java
@@ -232,13 +232,13 @@ public class NameFinderME implements TokenNameFinder {
 
     SequenceClassificationModel<String> seqModel = null;
 
-    TrainerType trainerType = TrainerFactory.getTrainerType(trainParams.getSettings());
+    TrainerType trainerType = TrainerFactory.getTrainerType(trainParams);
 
     if (TrainerType.EVENT_MODEL_TRAINER.equals(trainerType)) {
       ObjectStream<Event> eventStream = new NameFinderEventStream(samples, type,
               factory.createContextGenerator(), factory.createSequenceCodec());
 
-      EventTrainer trainer = TrainerFactory.getEventTrainer(trainParams.getSettings(), manifestInfoEntries);
+      EventTrainer trainer = TrainerFactory.getEventTrainer(trainParams, manifestInfoEntries);
       nameFinderModel = trainer.train(eventStream);
     } // TODO: Maybe it is not a good idea, that these two don't use the context generator ?!
     // These also don't use the sequence codec ?!
@@ -246,11 +246,11 @@ public class NameFinderME implements TokenNameFinder {
       NameSampleSequenceStream ss = new NameSampleSequenceStream(samples, factory.createContextGenerator());
 
       EventModelSequenceTrainer trainer = TrainerFactory.getEventModelSequenceTrainer(
-              trainParams.getSettings(), manifestInfoEntries);
+              trainParams, manifestInfoEntries);
       nameFinderModel = trainer.train(ss);
     } else if (TrainerType.SEQUENCE_TRAINER.equals(trainerType)) {
       SequenceTrainer trainer = TrainerFactory.getSequenceModelTrainer(
-              trainParams.getSettings(), manifestInfoEntries);
+              trainParams, manifestInfoEntries);
 
       NameSampleSequenceStream ss =
           new NameSampleSequenceStream(samples, factory.createContextGenerator(), false);

--- a/opennlp-tools/src/main/java/opennlp/tools/parser/chunking/Parser.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/parser/chunking/Parser.java
@@ -284,7 +284,7 @@ public class Parser extends AbstractBottomUpParser {
     ObjectStream<Event> bes = new ParserEventStream(parseSamples, rules, ParserEventTypeEnum.BUILD, mdict);
     Map<String, String> buildReportMap = new HashMap<>();
     EventTrainer buildTrainer =
-        TrainerFactory.getEventTrainer(mlParams.getSettings("build"), buildReportMap);
+        TrainerFactory.getEventTrainer(mlParams.getParameters("build"), buildReportMap);
     MaxentModel buildModel = buildTrainer.train(bes);
     mergeReportIntoManifest(manifestInfoEntries, buildReportMap, "build");
 
@@ -314,7 +314,7 @@ public class Parser extends AbstractBottomUpParser {
     ObjectStream<Event> kes = new ParserEventStream(parseSamples, rules, ParserEventTypeEnum.CHECK);
     Map<String, String> checkReportMap = new HashMap<>();
     EventTrainer checkTrainer =
-        TrainerFactory.getEventTrainer(mlParams.getSettings("check"), checkReportMap);
+        TrainerFactory.getEventTrainer(mlParams.getParameters("check"), checkReportMap);
     MaxentModel checkModel = checkTrainer.train(kes);
     mergeReportIntoManifest(manifestInfoEntries, checkReportMap, "check");
 

--- a/opennlp-tools/src/main/java/opennlp/tools/parser/treeinsert/Parser.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/parser/treeinsert/Parser.java
@@ -471,7 +471,7 @@ public class Parser extends AbstractBottomUpParser {
     Map<String, String> buildReportMap = new HashMap<>();
 
     EventTrainer buildTrainer = TrainerFactory.getEventTrainer(
-        mlParams.getSettings("build"), buildReportMap);
+        mlParams.getParameters("build"), buildReportMap);
     MaxentModel buildModel = buildTrainer.train(bes);
     opennlp.tools.parser.chunking.Parser.mergeReportIntoManifest(
         manifestInfoEntries, buildReportMap, "build");
@@ -485,7 +485,7 @@ public class Parser extends AbstractBottomUpParser {
     Map<String, String> checkReportMap = new HashMap<>();
 
     EventTrainer checkTrainer = TrainerFactory.getEventTrainer(
-        mlParams.getSettings("check"), checkReportMap);
+        mlParams.getParameters("check"), checkReportMap);
     MaxentModel checkModel = checkTrainer.train(kes);
     opennlp.tools.parser.chunking.Parser.mergeReportIntoManifest(
         manifestInfoEntries, checkReportMap, "check");
@@ -498,7 +498,7 @@ public class Parser extends AbstractBottomUpParser {
         ParserEventTypeEnum.ATTACH);
     Map<String, String> attachReportMap = new HashMap<>();
     EventTrainer attachTrainer = TrainerFactory.getEventTrainer(
-        mlParams.getSettings("attach"), attachReportMap);
+        mlParams.getParameters("attach"), attachReportMap);
     MaxentModel attachModel = attachTrainer.train(attachEvents);
     opennlp.tools.parser.chunking.Parser.mergeReportIntoManifest(
         manifestInfoEntries, attachReportMap, "attach");

--- a/opennlp-tools/src/main/java/opennlp/tools/postag/POSTaggerME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/postag/POSTaggerME.java
@@ -236,26 +236,26 @@ public class POSTaggerME implements POSTagger {
 
     Map<String, String> manifestInfoEntries = new HashMap<>();
 
-    TrainerType trainerType = TrainerFactory.getTrainerType(trainParams.getSettings());
+    TrainerType trainerType = TrainerFactory.getTrainerType(trainParams);
 
     MaxentModel posModel = null;
     SequenceClassificationModel<String> seqPosModel = null;
     if (TrainerType.EVENT_MODEL_TRAINER.equals(trainerType)) {
       ObjectStream<Event> es = new POSSampleEventStream(samples, contextGenerator);
 
-      EventTrainer trainer = TrainerFactory.getEventTrainer(trainParams.getSettings(),
+      EventTrainer trainer = TrainerFactory.getEventTrainer(trainParams,
           manifestInfoEntries);
       posModel = trainer.train(es);
     }
     else if (TrainerType.EVENT_MODEL_SEQUENCE_TRAINER.equals(trainerType)) {
       POSSampleSequenceStream ss = new POSSampleSequenceStream(samples, contextGenerator);
       EventModelSequenceTrainer trainer =
-          TrainerFactory.getEventModelSequenceTrainer(trainParams.getSettings(), manifestInfoEntries);
+          TrainerFactory.getEventModelSequenceTrainer(trainParams, manifestInfoEntries);
       posModel = trainer.train(ss);
     }
     else if (TrainerType.SEQUENCE_TRAINER.equals(trainerType)) {
       SequenceTrainer trainer = TrainerFactory.getSequenceModelTrainer(
-          trainParams.getSettings(), manifestInfoEntries);
+          trainParams, manifestInfoEntries);
 
       // TODO: This will probably cause issue, since the feature generator uses the outcomes array
 

--- a/opennlp-tools/src/main/java/opennlp/tools/sentdetect/SentenceDetectorME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/sentdetect/SentenceDetectorME.java
@@ -320,7 +320,7 @@ public class SentenceDetectorME implements SentenceDetector {
     ObjectStream<Event> eventStream = new SDEventStream(samples,
         sdFactory.getSDContextGenerator(), sdFactory.getEndOfSentenceScanner());
 
-    EventTrainer trainer = TrainerFactory.getEventTrainer(mlParams.getSettings(), manifestInfoEntries);
+    EventTrainer trainer = TrainerFactory.getEventTrainer(mlParams, manifestInfoEntries);
 
     MaxentModel sentModel = trainer.train(eventStream);
 

--- a/opennlp-tools/src/main/java/opennlp/tools/tokenize/TokenizerME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/tokenize/TokenizerME.java
@@ -242,7 +242,7 @@ public class TokenizerME extends AbstractTokenizer {
         factory.getAlphaNumericPattern(), factory.getContextGenerator());
 
     EventTrainer trainer = TrainerFactory.getEventTrainer(
-        mlParams.getSettings(), manifestInfoEntries);
+        mlParams, manifestInfoEntries);
 
     MaxentModel maxentModel = trainer.train(eventStream);
 

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/MockEventTrainer.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/MockEventTrainer.java
@@ -24,6 +24,7 @@ import opennlp.tools.ml.model.DataIndexer;
 import opennlp.tools.ml.model.Event;
 import opennlp.tools.ml.model.MaxentModel;
 import opennlp.tools.util.ObjectStream;
+import opennlp.tools.util.TrainingParameters;
 
 public class MockEventTrainer implements EventTrainer {
 
@@ -38,6 +39,11 @@ public class MockEventTrainer implements EventTrainer {
 
   @Override
   public void init(Map<String, String> trainParams,
+      Map<String, String> reportMap) {
+  }
+
+  @Override
+  public void init(TrainingParameters trainingParams,
       Map<String, String> reportMap) {
   }
 }

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/MockSequenceTrainer.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/MockSequenceTrainer.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import opennlp.tools.ml.model.AbstractModel;
 import opennlp.tools.ml.model.SequenceStream;
+import opennlp.tools.util.TrainingParameters;
 
 public class MockSequenceTrainer implements EventModelSequenceTrainer {
 
@@ -34,4 +35,9 @@ public class MockSequenceTrainer implements EventModelSequenceTrainer {
       Map<String, String> reportMap) {
   }
 
+  @Override
+  public void init(TrainingParameters trainParams,
+      Map<String, String> reportMap) {
+  }
+  
 }

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/TrainerFactoryTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/TrainerFactoryTest.java
@@ -40,25 +40,25 @@ public class TrainerFactoryTest {
 
   @Test
   public void testBuiltInValid() {
-    Assert.assertTrue(TrainerFactory.isValid(mlParams.getSettings()));
+    Assert.assertTrue(TrainerFactory.isValid(mlParams));
   }
 
   @Test
   public void testSequenceTrainerValid() {
     mlParams.put(TrainingParameters.ALGORITHM_PARAM, MockSequenceTrainer.class.getCanonicalName());
-    Assert.assertTrue(TrainerFactory.isValid(mlParams.getSettings()));
+    Assert.assertTrue(TrainerFactory.isValid(mlParams));
   }
 
   @Test
   public void testEventTrainerValid() {
     mlParams.put(TrainingParameters.ALGORITHM_PARAM, MockEventTrainer.class.getCanonicalName());
-    Assert.assertTrue(TrainerFactory.isValid(mlParams.getSettings()));
+    Assert.assertTrue(TrainerFactory.isValid(mlParams));
   }
 
   @Test
   public void testInvalidTrainer() {
     mlParams.put(TrainingParameters.ALGORITHM_PARAM, "xyz");
-    Assert.assertFalse(TrainerFactory.isValid(mlParams.getSettings()));
+    Assert.assertFalse(TrainerFactory.isValid(mlParams));
   }
 
   @Test
@@ -66,7 +66,7 @@ public class TrainerFactoryTest {
     mlParams.put(AbstractTrainer.ALGORITHM_PARAM,
         SimplePerceptronSequenceTrainer.PERCEPTRON_SEQUENCE_VALUE);
 
-    TrainerType trainerType = TrainerFactory.getTrainerType(mlParams.getSettings());
+    TrainerType trainerType = TrainerFactory.getTrainerType(mlParams);
 
     Assert.assertTrue(TrainerType.EVENT_MODEL_SEQUENCE_TRAINER.equals(trainerType));
   }
@@ -74,7 +74,7 @@ public class TrainerFactoryTest {
   @Test
   public void testIsSequenceTrainerFalse() {
     mlParams.put(AbstractTrainer.ALGORITHM_PARAM, GISTrainer.MAXENT_VALUE);
-    TrainerType trainerType = TrainerFactory.getTrainerType(mlParams.getSettings());
+    TrainerType trainerType = TrainerFactory.getTrainerType(mlParams);
     Assert.assertFalse(TrainerType.EVENT_MODEL_SEQUENCE_TRAINER.equals(trainerType));
   }
 

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/GISIndexingTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/GISIndexingTest.java
@@ -119,7 +119,7 @@ public class GISIndexingTest {
 
     // guarantee that you have a GIS trainer...
     EventTrainer trainer =
-        TrainerFactory.getEventTrainer(parameters.getSettings(), new HashMap<>());
+        TrainerFactory.getEventTrainer(parameters, new HashMap<>());
     Assert.assertEquals("opennlp.tools.ml.maxent.GISTrainer", trainer.getClass().getName());
     AbstractEventTrainer aeTrainer = (AbstractEventTrainer)trainer;
     // guarantee that you have a OnePassDataIndexer ...
@@ -137,7 +137,7 @@ public class GISIndexingTest {
     parameters.put(AbstractEventTrainer.DATA_INDEXER_PARAM, AbstractEventTrainer.DATA_INDEXER_TWO_PASS_VALUE);
     parameters.put(AbstractEventTrainer.CUTOFF_PARAM, "2");
     
-    trainer = TrainerFactory.getEventTrainer(parameters.getSettings(), new HashMap<>());
+    trainer = TrainerFactory.getEventTrainer(parameters, new HashMap<>());
     Assert.assertEquals("opennlp.tools.ml.maxent.quasinewton.QNTrainer", trainer.getClass().getName());
     aeTrainer = (AbstractEventTrainer)trainer;
     di = aeTrainer.getDataIndexer(eventStream);

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/MaxentPrepAttachTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/MaxentPrepAttachTest.java
@@ -19,7 +19,6 @@ package opennlp.tools.ml.maxent;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -75,7 +74,7 @@ public class MaxentPrepAttachTest {
   @Test
   public void testMaxentOnPrepAttachDataWithParams() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, GISTrainer.MAXENT_VALUE);
     trainParams.put(AbstractEventTrainer.DATA_INDEXER_PARAM,
         AbstractEventTrainer.DATA_INDEXER_TWO_PASS_VALUE);
@@ -90,7 +89,7 @@ public class MaxentPrepAttachTest {
   @Test
   public void testMaxentOnPrepAttachDataWithParamsDefault() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, GISTrainer.MAXENT_VALUE);
 
     EventTrainer trainer = TrainerFactory.getEventTrainer(trainParams, null);

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/quasinewton/QNPrepAttachTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/quasinewton/QNPrepAttachTest.java
@@ -19,7 +19,6 @@ package opennlp.tools.ml.maxent.quasinewton;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Test;
 
@@ -53,7 +52,7 @@ public class QNPrepAttachTest {
   @Test
   public void testQNOnPrepAttachDataWithParamsDefault() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, QNTrainer.MAXENT_QN_VALUE);
 
     MaxentModel model = TrainerFactory.getEventTrainer(trainParams, null)
@@ -65,7 +64,7 @@ public class QNPrepAttachTest {
   @Test
   public void testQNOnPrepAttachDataWithElasticNetParams() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, QNTrainer.MAXENT_QN_VALUE);
     trainParams.put(AbstractEventTrainer.DATA_INDEXER_PARAM,
         AbstractEventTrainer.DATA_INDEXER_TWO_PASS_VALUE);
@@ -82,7 +81,7 @@ public class QNPrepAttachTest {
   @Test
   public void testQNOnPrepAttachDataWithL1Params() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, QNTrainer.MAXENT_QN_VALUE);
     trainParams.put(AbstractEventTrainer.DATA_INDEXER_PARAM,
         AbstractEventTrainer.DATA_INDEXER_TWO_PASS_VALUE);
@@ -99,7 +98,7 @@ public class QNPrepAttachTest {
   @Test
   public void testQNOnPrepAttachDataWithL2Params() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, QNTrainer.MAXENT_QN_VALUE);
     trainParams.put(AbstractEventTrainer.DATA_INDEXER_PARAM,
         AbstractEventTrainer.DATA_INDEXER_TWO_PASS_VALUE);
@@ -116,7 +115,7 @@ public class QNPrepAttachTest {
   @Test
   public void testQNOnPrepAttachDataInParallel() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, QNTrainer.MAXENT_QN_VALUE);
     trainParams.put(QNTrainer.THREADS_PARAM, Integer.toString(2));
 

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/naivebayes/NaiveBayesPrepAttachTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/naivebayes/NaiveBayesPrepAttachTest.java
@@ -19,7 +19,6 @@ package opennlp.tools.ml.naivebayes;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -61,7 +60,7 @@ public class NaiveBayesPrepAttachTest {
 
   @Test
   public void testNaiveBayesOnPrepAttachDataUsingTrainUtil() throws IOException {
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, NaiveBayesTrainer.NAIVE_BAYES_VALUE);
     trainParams.put(AbstractTrainer.CUTOFF_PARAM, Integer.toString(1));
 
@@ -73,7 +72,7 @@ public class NaiveBayesPrepAttachTest {
 
   @Test
   public void testNaiveBayesOnPrepAttachDataUsingTrainUtilWithCutoff5() throws IOException {
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, NaiveBayesTrainer.NAIVE_BAYES_VALUE);
     trainParams.put(AbstractTrainer.CUTOFF_PARAM, Integer.toString(5));
 

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/perceptron/PerceptronPrepAttachTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/perceptron/PerceptronPrepAttachTest.java
@@ -23,7 +23,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,7 +57,7 @@ public class PerceptronPrepAttachTest {
   @Test
   public void testPerceptronOnPrepAttachDataWithSkippedAveraging() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, PerceptronTrainer.PERCEPTRON_VALUE);
     trainParams.put(AbstractTrainer.CUTOFF_PARAM, Integer.toString(1));
     trainParams.put("UseSkippedAveraging", Boolean.toString(true));
@@ -71,7 +70,7 @@ public class PerceptronPrepAttachTest {
   @Test
   public void testPerceptronOnPrepAttachDataWithTolerance() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, PerceptronTrainer.PERCEPTRON_VALUE);
     trainParams.put(AbstractTrainer.CUTOFF_PARAM, Integer.toString(1));
     trainParams.put(AbstractTrainer.ITERATIONS_PARAM, Integer.toString(500));
@@ -85,7 +84,7 @@ public class PerceptronPrepAttachTest {
   @Test
   public void testPerceptronOnPrepAttachDataWithStepSizeDecrease() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, PerceptronTrainer.PERCEPTRON_VALUE);
     trainParams.put(AbstractTrainer.CUTOFF_PARAM, Integer.toString(1));
     trainParams.put(AbstractTrainer.ITERATIONS_PARAM, Integer.toString(500));
@@ -99,7 +98,7 @@ public class PerceptronPrepAttachTest {
   @Test
   public void testModelSerialization() throws IOException {
 
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, PerceptronTrainer.PERCEPTRON_VALUE);
     trainParams.put(AbstractTrainer.CUTOFF_PARAM, Integer.toString(1));
     trainParams.put("UseSkippedAveraging", Boolean.toString(true));
@@ -123,7 +122,7 @@ public class PerceptronPrepAttachTest {
 
   @Test
   public void testModelEquals() throws IOException {
-    Map<String, String> trainParams = new HashMap<>();
+    TrainingParameters trainParams = new TrainingParameters();
     trainParams.put(AbstractTrainer.ALGORITHM_PARAM, PerceptronTrainer.PERCEPTRON_VALUE);
     trainParams.put(AbstractTrainer.CUTOFF_PARAM, Integer.toString(1));
     trainParams.put("UseSkippedAveraging", Boolean.toString(true));

--- a/opennlp-uima/src/main/java/opennlp/uima/util/OpennlpUtil.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/util/OpennlpUtil.java
@@ -82,11 +82,11 @@ final public class OpennlpUtil {
         throw new ResourceInitializationException(e);
       }
 
-      if (!TrainerFactory.isValid(params.getSettings())) {
+      if (!TrainerFactory.isValid(params)) {
         throw new ResourceInitializationException(new Exception("Training parameters file is invalid!"));
       }
 
-      TrainerFactory.TrainerType trainerType = TrainerFactory.getTrainerType(params.getSettings());
+      TrainerFactory.TrainerType trainerType = TrainerFactory.getTrainerType(params);
       if (!isSequenceTrainingAllowed && TrainerFactory.TrainerType.SEQUENCE_TRAINER.equals(trainerType)) {
         throw new ResourceInitializationException(new Exception("Sequence training is not supported!"));
       }


### PR DESCRIPTION
removed many .getSettings() to use the TrainingParameters methods and not the Map methods. added init(TrainingParameter,Map<String,String>) method to interfaces. 
