### PR TITLE
OPENNLP-989: Fix validation of CONT after START with different type

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/namefind/NameFinderSequenceValidator.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/namefind/NameFinderSequenceValidator.java
@@ -35,8 +35,9 @@ public class NameFinderSequenceValidator implements
         return false;
       } else if (outcomesSequence[li].endsWith(NameFinderME.OTHER)) {
         return false;
-      } else if (outcomesSequence[li].endsWith(NameFinderME.CONTINUE)) {
-        // if it is continue, we have to check if previous match was of the same type
+      } else if (outcomesSequence[li].endsWith(NameFinderME.CONTINUE) ||
+          outcomesSequence[li].endsWith(NameFinderME.START)) {
+        // if it is continue or start, we have to check if previous match was of the same type
         String previousNameType = NameFinderME.extractNameType(outcomesSequence[li]);
         String nameType = NameFinderME.extractNameType(outcome);
         if (previousNameType != null || nameType != null ) {

--- a/opennlp-tools/src/test/java/opennlp/tools/namefind/NameFinderSequenceValidatorTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/namefind/NameFinderSequenceValidatorTest.java
@@ -17,7 +17,6 @@
 package opennlp.tools.namefind;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -55,7 +54,6 @@ public class NameFinderSequenceValidatorTest {
 
   }
 
-  @Ignore
   @Test
   public void testContinueAfterStartAndNotSameType() {
 


### PR DESCRIPTION
Added same check as found in BilouNameFinderSequenceValidator. 
If outcome is CONT and previous was CONT or START then compare name types as part of the validation.