### PR TITLE
Fix typos in NER doc, and in package.html file

### DIFF
--- a/opennlp-docs/src/docbkx/namefinder.xml
+++ b/opennlp-docs/src/docbkx/namefinder.xml
@@ -388,7 +388,7 @@ new NameFinderME(model);]]>
 </generators>]]>
 				 </programlisting>
 		    The root element must be generators, each sub-element adds a feature generator to the configuration.
-		    The sample xml is constains additional feature generators with respect to the API defined above.
+		    The sample xml contains additional feature generators with respect to the API defined above.
 			</para>
 			<para>
 			The following table shows the supported elements:

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/package.html
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/package.html
@@ -28,6 +28,6 @@
 <body bgcolor="white">
 
 Provides the I/O functionality of the maxent package including reading
-and writting models in several formats.
+and writing models in several formats.
 </body>
 </html>


### PR DESCRIPTION
Found a couple more typos. The first one was right in front of me when I submitted another PR these days. The other was in a package HTML doc.