### PR TITLE
OPENNLP-1037: OpenNLP build fails if only the eval tests are run

### DIFF
--- a/opennlp-tools/pom.xml
+++ b/opennlp-tools/pom.xml
@@ -73,16 +73,7 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>/opennlp/tools/eval/**/*</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-			
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
 					<version>${maven.surefire.plugin}</version>
 					<configuration>
 						<forkCount>${opennlp.forkCount}</forkCount>
+						<failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
 						<excludes>
 							<exclude>**/stemmer/*</exclude>
 							<exclude>**/stemmer/snowball/*</exclude>
@@ -412,6 +413,30 @@
 					<plugin>
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>eval</id>
+			<activation>
+				<property>
+					<name>OPENNLP_DATA_DIR</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>${maven.surefire.plugin}</version>
+						<configuration>
+							<includes>
+								<include>**/*Test.java</include>
+								<include>**/SourceForgeModelEval.java</include>
+							</includes>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
**Modified the surefire configuration:**

"mvn test" will run all tests except those excluded in root pom (*see note)
"mvn eval" will run all tests and the "SourceForgeModelEval" test.

You can also run specific tests. e.g. "mvn test -DOPENNLP_DATA_DIR=/home/blue/opennlp-data-dir -Dtest=OntoNotes4Pos*"

**Implementations Notes:**
(Root pom.xml)
Added  <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests> to global surefire configuration to prevent failure if running specific tests from root folder e.g. mvn test -Dtest=Chunker*

Added profile "eval" which automatically is enabled if OPENNLP_DATA_DIR is defined. e.g. mvn test -DOPENNLP_DATA_DIR=/user/eval-data 

Eval profile: Explicit included tests: "\**/\*Test.java" and the eval test "\**/SourceForgeModelEval.java" which does not follow the normal name pattern and therefore needs to be explicit defined.
forkCount and failIdNoSpecifiedTests are same as global configuration.

The following tests are disabled. But I cannot figure out why. Can anybody recall why they were disabled?
/src/test/java/opennlp/tools/stemmer/PorterStemmerTest.java
/src/test/java/opennlp/tools/stemmer/SnowballStemmerTest.java