### PR TITLE
OPENNLP-1081: Fix Dictionary support to GeneratorFactory::extractArtifactSerializerMappings

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/GeneratorFactory.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/GeneratorFactory.java
@@ -47,6 +47,7 @@ import opennlp.tools.postag.POSModel;
 import opennlp.tools.util.InvalidFormatException;
 import opennlp.tools.util.ext.ExtensionLoader;
 import opennlp.tools.util.model.ArtifactSerializer;
+import opennlp.tools.util.model.DictionarySerializer;
 import opennlp.tools.util.model.POSModelSerializer;
 
 /**
@@ -844,6 +845,10 @@ public class GeneratorFactory {
 
             case "brownclusterbigram": //, ;
               mapping.put(dictName, new BrownCluster.BrownClusterSerializer());
+              break;
+
+            case "dictionary":
+              mapping.put(dictName, new DictionarySerializer());
               break;
           }
         }

--- a/opennlp-tools/src/test/java/opennlp/tools/util/featuregen/GeneratorFactoryTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/util/featuregen/GeneratorFactoryTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import opennlp.tools.util.InvalidFormatException;
 import opennlp.tools.util.featuregen.WordClusterDictionary.WordClusterDictionarySerializer;
 import opennlp.tools.util.model.ArtifactSerializer;
+import opennlp.tools.util.model.DictionarySerializer;
 
 public class GeneratorFactoryTest {
 
@@ -116,12 +117,25 @@ public class GeneratorFactoryTest {
   @Test
   public void testArtifactToSerializerMappingExtraction() throws IOException {
     // TODO: Define a new one here with custom elements ...
-    InputStream descIn = getClass().getResourceAsStream(
-        "/opennlp/tools/util/featuregen/CustomClassLoadingWithSerializers.xml");
+    try (InputStream descIn = getClass().getResourceAsStream(
+        "/opennlp/tools/util/featuregen/CustomClassLoadingWithSerializers.xml")) {
+      Map<String, ArtifactSerializer<?>> mapping =
+              GeneratorFactory.extractArtifactSerializerMappings(descIn);
 
-    Map<String, ArtifactSerializer<?>> mapping =
-        GeneratorFactory.extractArtifactSerializerMappings(descIn);
-
-    Assert.assertTrue(mapping.get("test.resource") instanceof WordClusterDictionarySerializer);
+      Assert.assertTrue(mapping.get("test.resource") instanceof WordClusterDictionarySerializer);
+    }
   }
+
+  @Test
+  public void testDictionaryArtifactToSerializerMappingExtraction() throws IOException {
+
+    try (InputStream descIn = getClass().getResourceAsStream(
+            "/opennlp/tools/util/featuregen/TestDictionarySerializerMappingExtractionxml")) {
+      Map<String, ArtifactSerializer<?>> mapping =
+              GeneratorFactory.extractArtifactSerializerMappings(descIn);
+
+      Assert.assertTrue(mapping.get("test.dictionary") instanceof DictionarySerializer);
+    }
+  }
+
 }

--- a/opennlp-tools/src/test/resources/opennlp/tools/util/featuregen/TestDictionarySerializerMappingExtractionxml
+++ b/opennlp-tools/src/test/resources/opennlp/tools/util/featuregen/TestDictionarySerializerMappingExtractionxml
@@ -1,0 +1,22 @@
+<!--
+	Licensed to the Apache Software Foundation (ASF) under one
+	or more contributor license agreements.  See the NOTICE file
+	distributed with this work for additional information
+	regarding copyright ownership.  The ASF licenses this file
+	to you under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+	
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+-->
+
+<generators>
+  <dictionary dict="test.dictionary"/>
+</generators>


### PR DESCRIPTION
Added Dictionary support "again"... (I think).

Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [√] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [√] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [√] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [√] Is your initial contribution a single, squashed commit?

### For code changes:
- [√] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [√] Have you written or updated unit tests to verify your changes?
- [√] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [na] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [na] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
