### PR TITLE
OPENNLP-1321 use LinkedHashMap for deterministic iteration order

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/AbstractModel.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/AbstractModel.java
@@ -19,7 +19,7 @@ package opennlp.tools.ml.model;
 
 import java.text.DecimalFormat;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -54,7 +54,7 @@ public abstract class AbstractModel implements MaxentModel {
   }
 
   private void init(String[] predLabels, Context[] params, String[] outcomeNames) {
-    this.pmap = new HashMap<>(predLabels.length);
+    this.pmap = new LinkedHashMap<>(predLabels.length);
 
     for (int i = 0; i < predLabels.length; i++) {
       pmap.put(predLabels[i], params[i]);

--- a/opennlp-tools/src/main/java/opennlp/tools/ngram/NGramModel.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ngram/NGramModel.java
@@ -20,7 +20,7 @@ package opennlp.tools.ngram;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -42,7 +42,7 @@ public class NGramModel implements Iterable<StringList> {
 
   protected static final String COUNT = "count";
 
-  private Map<StringList, Integer> mNGrams = new HashMap<>();
+  private Map<StringList, Integer> mNGrams = new LinkedHashMap<>();
 
   /**
    * Initializes an empty instance.

--- a/opennlp-tools/src/main/java/opennlp/tools/ngram/NGramModel.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ngram/NGramModel.java
@@ -20,8 +20,8 @@ package opennlp.tools.ngram;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.LinkedHashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 


### PR DESCRIPTION
The test `opennlp.tools.ml.naivebayes.NaiveBayesSerializedCorrectnessTest#testPlainTextModel` can fail due to a different iteration order of HashMap. The error message is as follows:

```
[ERROR] testPlainTextModel(opennlp.tools.ml.naivebayes.NaiveBayesSerializedCorrectnessTest)  Time elapsed: 0.01 s  <<< FAILURE!
org.junit.ComparisonFailure:
expected:<...ports
...
```

The fix is to change HaskMap to LinkedHashMap so that the iteration order remains stable and the failure will not occur any more. In this way, the test will be more stable.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
