### PR TITLE
OPENNLP-1330 Fix Parser's top "k" parses functionality from returning bottom "k" parses.

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/parser/AbstractBottomUpParser.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/parser/AbstractBottomUpParser.java
@@ -358,7 +358,7 @@ public abstract class AbstractBottomUpParser implements Parser {
     else {
       List<Parse> topParses = new ArrayList<>(numParses);
       while (!completeParses.isEmpty() && topParses.size() < numParses) {
-        Parse tp = completeParses.last();
+        Parse tp = completeParses.first();
         completeParses.remove(tp);
         topParses.add(tp);
         //parses.remove(tp);


### PR DESCRIPTION
 The default "top n parses" of 1 shows the most likely parse; one with a log prob of -2.9.

Passing in anything greater than 1 returns the least probable parses.

```
➜ bin git:(master) echo "Eric is testing." | ./opennlp Parser -k 1 ~/src/prhyme/resources/models/en-parser-chunking.bin
Loading Parser model ... done (2.515s)
0 -2.913239374955309 (TOP (S (NP (NNP Eric)) (VP (VBZ is)) (. testing.)))

Average: 41.7 sent/s
Total: 1 sent
Runtime: 0.024s
Execution time: 2.585 seconds
➜ bin git:(master) echo "Eric is testing." | ./opennlp Parser -k 2 ~/src/prhyme/resources/models/en-parser-chunking.bin
Loading Parser model ... done (2.578s)
0 -14.968552218782305 (TOP (S (NP (NNP Eric)) (SBAR (S (ADVP (VBZ is)) (VBG testing.)))))
1 -13.957766393572408 (TOP (S (SBAR (S (NP (NNP Eric)) (ADVP (VBZ is)))) (VBG testing.)))

Average: 95.2 sent/s
Total: 2 sent
Runtime: 0.021s
Execution time: 2.640 seconds
```

The fix is clear and simple. We should be taking from the first of the TreeSet rather than from the end.

```
 else if (numParses == 1) {
 return new Parse[] {completeParses.first()};
 }
 else {
 List<Parse> topParses = new ArrayList<>(numParses);
 while (!completeParses.isEmpty() && topParses.size() < numParses) {
 Parse tp = completeParses.last();      //// <--- Change to .first()
 completeParses.remove(tp);
 topParses.add(tp);
 //parses.remove(tp);
 }
 return topParses.toArray(new Parse[topParses.size()]);
 }
```

After patch, results are what I expect.

 ```
➜ bin git:(master) ✗ echo "Eric is testing." | ./opennlp Parser -k 1 ~/src/prhyme/resources/models/en-parser-chunking.bin
Loading Parser model ... done (2.517s)
0 -2.913239374955309 (TOP (S (NP (NNP Eric)) (VP (VBZ is)) (. testing.)))

Average: 45.5 sent/s
Total: 1 sent
Runtime: 0.022s
Execution time: 2.580 seconds
➜ bin git:(master) ✗ echo "Eric is testing." | ./opennlp Parser -k 2 ~/src/prhyme/resources/models/en-parser-chunking.bin
Loading Parser model ... done (2.530s)
0 -2.913239374955309 (TOP (S (NP (NNP Eric)) (VP (VBZ is)) (. testing.)))
1 -3.1132674983145825 (TOP (S (NP (NNP Eric)) (VP (VBZ is) (NP (NN testing.)))))

Average: 90.9 sent/s
Total: 2 sent
Runtime: 0.022s
Execution time: 2.596 seconds

```
 
Jira issue link: https://issues.apache.org/jira/browse/OPENNLP-1330

Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes? (I chose not to. If this is a requirement, I may be able to spend time on this.)
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
