### PR TITLE
OPENNLP-1354: Fixing javadoc generation on Java 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,8 @@
 				<version>3.1.1</version>
 				<configuration>
 					<doclint>none</doclint>
+					<source>8</source>
+					<sourcepath>src/main/java</sourcepath>
 				</configuration>
 				<executions>
 					<execution>
@@ -364,7 +366,6 @@
 							<show>public</show>
 							<quiet>false</quiet>
 							<use>false</use> <!-- Speeds up the build of the javadocs -->
-							<source>8</source>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
I ran into this issue while cutting the 2.0 release. Javadocs on JDK 11 would not build without these changes. The source 8 looks weird since we're on Java 11 but is a recommended workaround for the time being.

---

Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
