### PR TITLE
OPENNLP-1386: Making parameters be not case sensitive.

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/util/TrainingParameters.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/TrainingParameters.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.TreeMap;
 
 import opennlp.tools.ml.EventTrainer;
 
@@ -38,7 +39,7 @@ public class TrainingParameters {
   public static final String CUTOFF_PARAM = "Cutoff";
   public static final String THREADS_PARAM = "Threads";
 
-  private Map<String, Object> parameters = new HashMap<>();
+  private Map<String, Object> parameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
   public TrainingParameters() {
   }

--- a/opennlp-tools/src/test/java/opennlp/tools/util/TrainingParametersTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/util/TrainingParametersTest.java
@@ -69,6 +69,14 @@ public class TrainingParametersTest {
   }
 
   @Test
+  public void testGetAlgorithmCaseInsensitive() {
+    TrainingParameters tp = build("ALGORITHM=Perceptron,n1.Algorithm=SVM");
+
+    Assert.assertEquals("Perceptron", tp.algorithm());
+    Assert.assertEquals("SVM", tp.algorithm("n1"));
+  }
+
+  @Test
   public void testGetSettings() {
     TrainingParameters tp = build("k1=v1,n1.k2=v2,n2.k3=v3,n1.k4=v4");
 


### PR DESCRIPTION
This change makes the parameters case insensitive. So, in `params.txt` when training a model, you can have `Cutoff=5`, `cutoff=5`, and `CUTOFF=5` all work and not have to have the parameter key match the case of what's in `TrainingParameters.java`.

---

Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
