### PR TITLE
OPENNLP-1320: Makes lemmatize of MorfologikLemmatizer thread-safe (v2)

### DIFF
--- a/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/lemmatizer/MorfologikLemmatizer.java
+++ b/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/lemmatizer/MorfologikLemmatizer.java
@@ -28,27 +28,25 @@ import java.util.Set;
 
 import morfologik.stemming.Dictionary;
 import morfologik.stemming.DictionaryLookup;
-import morfologik.stemming.IStemmer;
 import morfologik.stemming.WordData;
 
 import opennlp.tools.lemmatizer.Lemmatizer;
 
 public class MorfologikLemmatizer implements Lemmatizer {
 
-  private IStemmer dictLookup;
+  private final Dictionary dictionary;
 
   public MorfologikLemmatizer(Path dictionaryPath) throws IllegalArgumentException,
       IOException {
     this(Dictionary.read(dictionaryPath));
   }
 
-  public MorfologikLemmatizer(Dictionary dictionary) throws IllegalArgumentException,
-      IOException {
-    dictLookup = new DictionaryLookup(dictionary);
+  public MorfologikLemmatizer(Dictionary dictionary) throws IllegalArgumentException {
+    this.dictionary = dictionary;
   }
 
-  private synchronized List<String> lemmatize(String word, String postag) {
-    List<WordData> dictMap = dictLookup.lookup(word.toLowerCase());
+  private List<String> lemmatize(String word, String postag) {
+    List<WordData> dictMap = new DictionaryLookup(dictionary).lookup(word.toLowerCase());
     Set<String> lemmas = new HashSet<>();
     for (WordData wordData : dictMap) {
       if (Objects.equals(postag, asString(wordData.getTag()))) {

--- a/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/lemmatizer/MorfologikLemmatizer.java
+++ b/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/lemmatizer/MorfologikLemmatizer.java
@@ -47,7 +47,7 @@ public class MorfologikLemmatizer implements Lemmatizer {
     dictLookup = new DictionaryLookup(dictionary);
   }
 
-  private List<String> lemmatize(String word, String postag) {
+  private synchronized List<String> lemmatize(String word, String postag) {
     List<WordData> dictMap = dictLookup.lookup(word.toLowerCase());
     Set<String> lemmas = new HashSet<>();
     for (WordData wordData : dictMap) {

--- a/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/builder/POSDictionayBuilderTest.java
+++ b/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/builder/POSDictionayBuilderTest.java
@@ -70,8 +70,8 @@ public class POSDictionayBuilderTest {
 
     Runnable runnable = () -> {
       String[] lemmas = lemmatizer.lemmatize(toks, tags);
-      Assert.assertEquals("casa", lemmas[0]);
-      Assert.assertEquals("casar", lemmas[1]);
+      Assertions.assertEquals("casa", lemmas[0]);
+      Assertions.assertEquals("casar", lemmas[1]);
     };
     ExecutorService executorService = Executors.newFixedThreadPool(2);
     for (int i = 0; i < 1000; i++) {


### PR DESCRIPTION
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Additional Notes

This is a PR on the basis of https://github.com/apache/opennlp/pull/385 with the JUnit 4 test by @avanco 

As commented in https://github.com/apache/opennlp/pull/385, this PR proposes to re-create and dispose the `DictionaryLookup`, which is " is cheap to create and dispose (so it makes no sense to cache)" according to https://github.com/morfologik/morfologik-stemming/issues/69 - it avoids the explicit sychronization of the method.

I did not squash the commits to retain @avanco code contributions / authorship.
