### PR TITLE
OPENNLP-1425 Remove long-time deprecated update method in AbstractDataIndexer

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/AbstractDataIndexer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/AbstractDataIndexer.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import opennlp.tools.ml.AbstractTrainer;
 import opennlp.tools.util.InsufficientTrainingDataException;
@@ -83,6 +82,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   /**
    * {@inheritDoc}
    */
+  @Override
   public int[][] getContexts() {
     return contexts;
   }
@@ -90,6 +90,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   /**
    * {@inheritDoc}
    */
+  @Override
   public int[] getNumTimesEventsSeen() {
     return numTimesEventsSeen;
   }
@@ -97,6 +98,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   /**
    * {@inheritDoc}
    */
+  @Override
   public int[] getOutcomeList() {
     return outcomeList;
   }
@@ -104,6 +106,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   /**
    * {@inheritDoc}
    */
+  @Override
   public String[] getPredLabels() {
     return predLabels;
   }
@@ -111,6 +114,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   /**
    * {@inheritDoc}
    */
+  @Override
   public String[] getOutcomeLabels() {
     return outcomeLabels;
   }
@@ -118,6 +122,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   /**
    * {@inheritDoc}
    */
+  @Override
   public int[] getPredCounts() {
     return predCounts;
   }
@@ -125,6 +130,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   /**
    * {@inheritDoc}
    */
+  @Override
   public int getNumEvents() {
     return numEvents;
   }
@@ -231,28 +237,6 @@ public abstract class AbstractDataIndexer implements DataIndexer {
     outcomeLabels = toIndexedStringArray(omap);
     predLabels = toIndexedStringArray(predicateIndex);
     return eventsToCompare;
-  }
-
-  /**
-   * Updates the set of predicates and counter with the specified event contexts and cutoff.
-   *
-   * @param ec The contexts/features which occur in a event.
-   * @param predicateSet The set of predicates which will be used for model building.
-   * @param counter The predicate counters.
-   * @param cutoff The cutoff which determines whether a predicate is included.
-   *
-   * @deprecated Use {{@link #update(String[], Map)}}. This method will be removed after 1.8.1 release
-   */
-  @Deprecated
-  protected static void update(String[] ec, Set<String> predicateSet,
-      Map<String,Integer> counter, int cutoff) {
-    for (String s : ec) {
-      counter.merge(s, 1, (value, one) -> value + one);
-
-      if (!predicateSet.contains(s) && counter.get(s) >= cutoff) {
-        predicateSet.add(s);
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
Change
-
- removes `update(String[] ec, Set<String> predicateSet, Map<String,Integer> counter, int cutoff)` method from `AbstractDataIndexer` _deprecated_ for quite a long time and which was _unused_ in OpenNLP code
- adds 'Override' annotation where useful and applicable

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
