### PR TITLE
OPENNLP-1367 Update checkstyle rules for a recent checkstyle version

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -29,8 +29,15 @@
 
   <property name="fileExtensions" value="java, properties, xml"/>
 
-  <module name="SuppressionCommentFilter"/>
-
+  <!--
+    Special exclusion for source files in snowball package which have a special copyright situation.
+    Background: Comment-based filtering changed in checkstyle 8+.
+    Therefore, the exclusion must be handled explicitly, otherwise the 'RegexpHeader' check would fail.
+   -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value=".*[\\/]src[\\/]main[\\/]java[\\/]opennlp[\\/]tools[\\/]stemmer[\\/]snowball.*$"/>
+  </module>
+  
   <module name="RegexpHeader">
     <property name="header"
               value="^.*$\n^\W*Licensed to the Apache Software Foundation \(ASF\) under one or more$"/>
@@ -40,6 +47,11 @@
   <!-- See http://checkstyle.sf.net/config_whitespace.html -->
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="max" value="110"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
   </module>
 
   <module name="NewlineAtEndOfFile">
@@ -52,16 +64,12 @@
   </module>
 
   <module name="TreeWalker">
-    <module name="FileContentsHolder"/>
+    <module name="SuppressionCommentFilter"/>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
       <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
       <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
-    </module>
-    <module name="LineLength">
-      <property name="max" value="110"/>
-      <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
     <module name="UnusedImports"/>
@@ -123,6 +131,7 @@
     <module name="CustomImportOrder">
       <property name="sortImportsInGroupAlphabetically" value="true"/>
       <property name="separateLineBetweenGroups" value="true"/>
+      <property name="standardPackageRegExp" value="^(java|javax)\."/>
       <property name="specialImportsRegExp" value="opennlp\."/>
       <property name="customImportOrderRules"
                 value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STATIC"/>

--- a/opennlp-brat-annotator/src/main/java/opennlp/bratann/NameFinderAnnService.java
+++ b/opennlp-brat-annotator/src/main/java/opennlp/bratann/NameFinderAnnService.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
-
 import javax.ws.rs.core.UriBuilder;
 
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;

--- a/opennlp-brat-annotator/src/main/java/opennlp/bratann/NameFinderResource.java
+++ b/opennlp-brat-annotator/src/main/java/opennlp/bratann/NameFinderResource.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;

--- a/opennlp-dl/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
+++ b/opennlp-dl/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 
 import ai.onnxruntime.OrtException;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/opennlp-dl/src/test/java/opennlp/dl/namefinder/NameFinderDLEval.java
+++ b/opennlp-dl/src/test/java/opennlp/dl/namefinder/NameFinderDLEval.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import ai.onnxruntime.OrtException;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/tagdict/MorfologikTagDictionaryTest.java
+++ b/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/tagdict/MorfologikTagDictionaryTest.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import morfologik.stemming.Dictionary;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/opennlp-tools/src/main/java/opennlp/tools/dictionary/serializer/DictionaryEntryPersistor.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/dictionary/serializer/DictionaryEntryPersistor.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/frenchtreebank/ConstitParseSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/frenchtreebank/ConstitParseSampleStream.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.parsers.SAXParser;
 
 import org.xml.sax.SAXException;

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/irishsentencebank/IrishSentenceBankDocument.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/irishsentencebank/IrishSentenceBankDocument.java
@@ -20,7 +20,6 @@ package opennlp.tools.formats.irishsentencebank;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.StringBuilder;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.xml.parsers.DocumentBuilder;
 
 import org.w3c.dom.Document;
@@ -198,7 +196,7 @@ public class IrishSentenceBankDocument {
           List<Span> spans = new ArrayList<>();
           NodeList sentnl = sentnode.getChildNodes();
           int flexes = 1;
-          StringBuilder orig = new StringBuilder();
+          java.lang.StringBuilder orig = new java.lang.StringBuilder();
 
           for (int j = 0; j < sentnl.getLength(); j++) {
             final String name = sentnl.item(j).getNodeName();

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/letsmt/LetsmtDocument.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/letsmt/LetsmtDocument.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import javax.xml.parsers.SAXParser;
 
 import org.xml.sax.InputSource;

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocument.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocument.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.parsers.SAXParser;
 
 import org.xml.sax.SAXException;

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocumentStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocumentStream.java
@@ -29,7 +29,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
-
 import javax.xml.parsers.SAXParser;
 
 import org.xml.sax.Attributes;

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/nkjp/NKJPTextDocument.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/nkjp/NKJPTextDocument.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/ModelParameterChunker.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/ModelParameterChunker.java
@@ -71,7 +71,7 @@ public final class ModelParameterChunker {
 
   private static final int MAX_CHUNK_SIZE_BYTES = 65535; // the maximum 'utflen' DataOutputStream can handle
 
-  private ModelParameterChunker(){
+  private ModelParameterChunker() {
     // private utility class ct s
   }
 

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/OnePassDataIndexer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/OnePassDataIndexer.java
@@ -36,7 +36,7 @@ import opennlp.tools.util.ObjectStreamUtils;
  */
 public class OnePassDataIndexer extends AbstractDataIndexer {
 
-  public OnePassDataIndexer(){}
+  public OnePassDataIndexer() {}
 
   /**
    * {@inheritDoc}

--- a/opennlp-tools/src/main/java/opennlp/tools/namefind/DefaultNameContextGenerator.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/namefind/DefaultNameContextGenerator.java
@@ -72,7 +72,7 @@ public class DefaultNameContextGenerator implements NameContextGenerator {
     }
     else { // use defaults
       this.featureGenerators =
-        new AdaptiveFeatureGenerator[]{WINDOW_FEATURES, new PreviousMapFeatureGenerator()};
+          new AdaptiveFeatureGenerator[]{WINDOW_FEATURES, new PreviousMapFeatureGenerator()};
     }
   }
 

--- a/opennlp-tools/src/main/java/opennlp/tools/sentdetect/SentenceDetector.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/sentdetect/SentenceDetector.java
@@ -26,22 +26,22 @@ import opennlp.tools.util.Span;
  */
 public interface SentenceDetector {
 
-    /**
-     * Detects sentences in a character sequence.
-     *
-     * @param s The {@link CharSequence} for which sentences shall to be detected.
-     * @return  The String[] with the individual sentences as the array
-     *          elements.
-     */
-    String[] sentDetect(CharSequence s);
+  /**
+   * Detects sentences in a character sequence.
+   *
+   * @param s The {@link CharSequence} for which sentences shall to be detected.
+   * @return  The String[] with the individual sentences as the array
+   *          elements.
+   */
+  String[] sentDetect(CharSequence s);
 
-    /**
-     * Detects sentences in a character sequence.
-     *
-     * @param s The {@link CharSequence} for which sentences shall be detected.
-     *
-     * @return The array of {@link Span spans} (offsets into {@code s}) for each
-     * detected sentence as the individuals array elements.
-     */
-    Span[] sentPosDetect(CharSequence s);
+  /**
+   * Detects sentences in a character sequence.
+   *
+   * @param s The {@link CharSequence} for which sentences shall be detected.
+   *
+   * @return The array of {@link Span spans} (offsets into {@code s}) for each
+   * detected sentence as the individuals array elements.
+   */
+  Span[] sentPosDetect(CharSequence s);
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/util/Version.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/Version.java
@@ -75,7 +75,7 @@ public class Version {
    * @param revision Must not be negative.
    */
   public Version(int major, int minor, int revision) {
-   this(major, minor, revision, false);
+    this(major, minor, revision, false);
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/GeneratorFactory.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/GeneratorFactory.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;

--- a/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/TokenPatternFeatureGenerator.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/TokenPatternFeatureGenerator.java
@@ -39,7 +39,7 @@ public class TokenPatternFeatureGenerator implements AdaptiveFeatureGenerator {
    * For tokenization the {@link SimpleTokenizer} is used.
    */
   public TokenPatternFeatureGenerator() {
-      this(SimpleTokenizer.INSTANCE);
+    this(SimpleTokenizer.INSTANCE);
   }
 
   /**

--- a/opennlp-tools/src/test/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerToolTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerToolTest.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
-
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/Conll02NameFinderEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/Conll02NameFinderEval.java
@@ -19,7 +19,6 @@ package opennlp.tools.eval;
 
 import java.io.File;
 import java.io.IOException;
-
 import java.math.BigInteger;
 
 import org.junit.jupiter.api.Assertions;

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/OntoNotes4PosTaggerEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/OntoNotes4PosTaggerEval.java
@@ -20,7 +20,6 @@ package opennlp.tools.eval;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
-
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Assertions;

--- a/opennlp-tools/src/test/java/opennlp/tools/langdetect/LanguageDetectorCrossValidatorTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/langdetect/LanguageDetectorCrossValidatorTest.java
@@ -19,7 +19,6 @@ package opennlp.tools.langdetect;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/opennlp-tools/src/test/java/opennlp/tools/util/MockInputStreamFactory.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/util/MockInputStreamFactory.java
@@ -20,7 +20,6 @@ package opennlp.tools.util;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
-
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 

--- a/opennlp-uima/src/main/java/opennlp/uima/util/UimaUtil.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/util/UimaUtil.java
@@ -31,7 +31,7 @@ import org.apache.uima.cas.text.AnnotationFS;
  */
 public final class UimaUtil {
 
-  private UimaUtil(){
+  private UimaUtil() {
     // this is util class must not be instantiated
   }
 

--- a/opennlp-uima/src/test/java/opennlp/uima/AnnotatorsInitializationTest.java
+++ b/opennlp-uima/src/test/java/opennlp/uima/AnnotatorsInitializationTest.java
@@ -27,7 +27,6 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.ResourceSpecifier;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
-
 import org.junit.jupiter.api.Assertions;
 
 /**

--- a/opennlp-uima/src/test/java/opennlp/uima/dictionary/DictionaryResourceTest.java
+++ b/opennlp-uima/src/test/java/opennlp/uima/dictionary/DictionaryResourceTest.java
@@ -33,7 +33,6 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.ResourceSpecifier;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;

--- a/opennlp-uima/src/test/java/opennlp/uima/util/AnnotationComboIteratorTest.java
+++ b/opennlp-uima/src/test/java/opennlp/uima/util/AnnotationComboIteratorTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/opennlp-uima/src/test/java/opennlp/uima/util/CasUtil.java
+++ b/opennlp-uima/src/test/java/opennlp/uima/util/CasUtil.java
@@ -20,7 +20,6 @@ package opennlp.uima.util;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -38,7 +37,6 @@ import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
 import org.apache.uima.util.XMLParser;
-
 import org.xml.sax.SAXException;
 
 public class CasUtil {

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 		<junit.version>5.9.1</junit.version>
 		<morfologik.version>2.1.7</morfologik.version>
 		<osgi.version>4.2.0</osgi.version>
-		<checkstyle.plugin.version>2.17</checkstyle.plugin.version>
+		<checkstyle.plugin.version>3.2.0</checkstyle.plugin.version>
 		<onnxruntime.version>1.10.0</onnxruntime.version>
 		<opennlp.forkCount>1.0C</opennlp.forkCount>
 		<coveralls.maven.plugin>4.3.0</coveralls.maven.plugin>
@@ -203,7 +203,7 @@
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
-							<version>7.2</version>
+							<version>10.6.0</version>
 						</dependency>
 					</dependencies>
 					<executions>
@@ -212,10 +212,9 @@
 							<phase>validate</phase>
 							<configuration>
 								<configLocation>checkstyle.xml</configLocation>
-								<encoding>UTF-8</encoding>
 								<consoleOutput>true</consoleOutput>
 								<includeTestSourceDirectory>true</includeTestSourceDirectory>
-								<testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
+								<testSourceDirectories>${project.basedir}/src/test/java</testSourceDirectories>
 								<violationSeverity>error</violationSeverity>
 								<failOnViolation>true</failOnViolation>
 							</configuration>


### PR DESCRIPTION
Change
-
- updates maven-checkstyle plugin to the latest version 3.2.0 (from outdated 2.17)
- updates checkstyle from ancient version 7.2 to most recent version 10.6
- adjusts configuration `checkstyle.xml` to match the requirements of checkstyle 10.x
- adjusts some code fragments that caused complaints by checkstyle 10.x
- fixed previously undetected violations, such as wrong indentations or missing whitespaces, now being detected

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
