### PR TITLE
OPENNLP-1445 - Run GH action "Publish snapshots" only on ASF repo

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   publish:
     name: Publish snapshot artifacts
+    if: github.repository == 'apache/opennlp'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:

- Don't run publish snapshots on forked repositories (as they do not have the secrets available and will fail as reported by @mawiesne )

- Similar fix / action as done by Spark in https://github.com/apache/spark/blob/master/.github/workflows/publish_snapshot.yml#L28
