### PR TITLE
OPENNLP-1448 - Introduce SLF4J in OpenNLP

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -277,3 +277,29 @@ The following license applies to the ONNX Runtime:
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
+
+The following license applies to the SLF4J API:
+
+    MIT license
+
+    Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+    All rights reserved.
+
+    Permission is hereby granted, free  of charge, to any person obtaining
+    a  copy  of this  software  and  associated  documentation files  (the
+    "Software"), to  deal in  the Software without  restriction, including
+    without limitation  the rights to  use, copy, modify,  merge, publish,
+    distribute,  sublicense, and/or sell  copies of  the Software,  and to
+    permit persons to whom the Software  is furnished to do so, subject to
+    the following conditions:
+
+    The  above  copyright  notice  and  this permission  notice  shall  be
+    included in all copies or substantial portions of the Software.
+
+    THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+    EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+    MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -64,3 +64,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+============================================================================
+
+SLF4J API
+https://github.com/qos-ch/slf4j
+
+MIT License
+
+Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/opennlp-brat-annotator/pom.xml
+++ b/opennlp-brat-annotator/pom.xml
@@ -32,6 +32,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-grizzly2-http</artifactId>
 			<version>${glassfish.version}</version>
@@ -57,6 +62,12 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/opennlp-brat-annotator/src/main/bin/brat-annotation-service
+++ b/opennlp-brat-annotator/src/main/bin/brat-annotation-service
@@ -32,4 +32,4 @@ fi
 # Might fail if $0 is a link
 OPENNLP_HOME=`dirname "$0"`/..
 
-$JAVACMD -Xmx1024m -cp "$OPENNLP_HOME/lib/*" opennlp.bratann.NameFinderAnnService $@
+$JAVACMD -Xmx1024m -Dlog4j.configurationFile=../conf/log4j2.xml -cp "$OPENNLP_HOME/lib/*" opennlp.bratann.NameFinderAnnService $@

--- a/opennlp-brat-annotator/src/main/bin/brat-annotation-service.bat
+++ b/opennlp-brat-annotator/src/main/bin/brat-annotation-service.bat
@@ -46,6 +46,6 @@ FOR %%A IN ("%OPENNLP_HOME%\lib\*.jar") DO (
 )
 set CLASSPATH=!CLASSPATH!"
 
-%JAVA_CMD% -Xmx1024m -cp %CLASSPATH% opennlp.bratann.NameFinderAnnService %*
+%JAVA_CMD% -Xmx1024m "-Dlog4j.configurationFile=%OPENNLP_HOME%\conf\log4j2.xml" -cp %CLASSPATH% opennlp.bratann.NameFinderAnnService %*
 
 ENDLOCAL

--- a/opennlp-brat-annotator/src/main/java/opennlp/bratann/NameFinderAnnService.java
+++ b/opennlp-brat-annotator/src/main/java/opennlp/bratann/NameFinderAnnService.java
@@ -25,6 +25,8 @@ import javax.ws.rs.core.UriBuilder;
 
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.tools.namefind.NameFinderME;
 import opennlp.tools.namefind.TokenNameFinder;
@@ -41,6 +43,7 @@ import opennlp.tools.tokenize.WhitespaceTokenizer;
 
 public class NameFinderAnnService {
 
+  private static Logger logger = LoggerFactory.getLogger(NameFinderAnnService.class);
   public static SentenceDetector sentenceDetector = new NewlineSentenceDetector();
   public static Tokenizer tokenizer = WhitespaceTokenizer.INSTANCE;
   public static TokenNameFinder[] nameFinders;
@@ -48,8 +51,8 @@ public class NameFinderAnnService {
   public static void main(String[] args) throws Exception {
 
     if (args.length == 0) {
-      System.out.println("Usage:");
-      System.out.println("[NameFinderAnnService -serverPort port] [-tokenizerModel file] "
+      logger.info("Usage:");
+      logger.info("[NameFinderAnnService -serverPort port] [-tokenizerModel file] "
           + "[-ruleBasedTokenizer whitespace|simple] "
           + "[-sentenceDetectorModel file] namefinderFile|nameFinderURI");
       return;
@@ -78,7 +81,7 @@ public class NameFinderAnnService {
       } else if ("simple".equals(args[ruleBasedTokenizerIndex])) {
         tokenizer = SimpleTokenizer.INSTANCE;
       } else {
-        System.out.println("unknown tokenizer: " + args[ruleBasedTokenizerIndex]);
+        logger.error("unknown tokenizer: " + args[ruleBasedTokenizerIndex]);
         return;
       }
     }

--- a/opennlp-distr/pom.xml
+++ b/opennlp-distr/pom.xml
@@ -54,6 +54,17 @@
             <groupId>org.apache.opennlp</groupId>
             <artifactId>opennlp-brat-annotator</artifactId>
         </dependency>
+		<!-- ship the dist with a logging impl for cli users -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j2.version}</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/opennlp-distr/src/main/assembly/bin.xml
+++ b/opennlp-distr/src/main/assembly/bin.xml
@@ -20,132 +20,142 @@
 -->
 
 <assembly>
-  <id>bin</id>
-  <formats>
-    <format>tar.gz</format>
-    <format>zip</format>
-  </formats>
-  
+    <id>bin</id>
+    <formats>
+        <format>tar.gz</format>
+        <format>zip</format>
+    </formats>
+
     <includeBaseDirectory>true</includeBaseDirectory>
-	<baseDirectory>/apache-opennlp-${project.version}</baseDirectory>
-	
-	<dependencySets>
-		<dependencySet>
-			<scope>runtime</scope>
-			<unpack>false</unpack>
-			<useProjectArtifact>false</useProjectArtifact>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>lib</outputDirectory>
-			<useTransitiveDependencies>true</useTransitiveDependencies>
-		</dependencySet>
-	</dependencySets>
-	
-	<fileSets>
-	    <fileSet>
-	    	<directory>src/main/readme</directory>
-	    	<fileMode>644</fileMode>
-	    	<directoryMode>755</directoryMode>
-	    	<outputDirectory>.</outputDirectory>
-	    </fileSet>
-		
-	    <fileSet>
-	      <directory>.</directory>
-	      <filtered>true</filtered>
-	      <fileMode>644</fileMode>
-	      <directoryMode>755</directoryMode> 
-	      <includes>
-	        <include>RELEASE_NOTES.html</include>
-	      </includes>       
-	    </fileSet>
+    <baseDirectory>/apache-opennlp-${project.version}</baseDirectory>
 
-	    <fileSet>
-	      <directory>target</directory>
-	      <fileMode>644</fileMode>
-	      <directoryMode>755</directoryMode>
-	      <outputDirectory>.</outputDirectory>
-	      <includes>
-	        <include>README.html</include>
-	      </includes>
-	    </fileSet>
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <unpack>false</unpack>
+            <useProjectArtifact>false</useProjectArtifact>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>lib</outputDirectory>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+        </dependencySet>
+    </dependencySets>
 
-	    <fileSet>
-	      <directory>target/issuesFixed</directory>
-	      <fileMode>644</fileMode>
-	      <directoryMode>755</directoryMode>
-	      <outputDirectory>issuesFixed</outputDirectory>
-	    </fileSet>
-	    
-		<fileSet>
-			<directory>src/main/bin</directory>
-			<fileMode>755</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>bin</outputDirectory>
-		</fileSet>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/readme</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
 
-		<fileSet>
-			<directory>../opennlp-morfologik-addon/src/main/bin</directory>
-			<fileMode>755</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>bin</outputDirectory>
-		</fileSet>
-		
-		<fileSet>
-			<directory>../opennlp-brat-annotator/src/main/bin</directory>
-			<fileMode>755</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>bin</outputDirectory>
-		</fileSet>
+        <fileSet>
+            <directory>src/main/resources</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>conf</outputDirectory>
+            <includes>
+                <include>log4j2.xml</include>
+            </includes>
+        </fileSet>
 
-		<fileSet>
-			<directory>../opennlp-tools/lang</directory>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>lang</outputDirectory>
-		</fileSet>
-		
-		<fileSet>
-			<directory>../opennlp-docs/target/docbkx/html</directory>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>docs/manual</outputDirectory>
-		</fileSet>
-		
-		<fileSet>
-			<directory>../opennlp-tools/target/apidocs</directory>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>docs/apidocs/opennlp-tools</outputDirectory>
-		</fileSet>
+        <fileSet>
+            <directory>.</directory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <includes>
+                <include>RELEASE_NOTES.html</include>
+            </includes>
+        </fileSet>
 
-		<fileSet>
-			<directory>../opennlp-brat-annotator/target/apidocs</directory>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>docs/apidocs/opennlp-brat-annotator</outputDirectory>
-		</fileSet>
+        <fileSet>
+            <directory>target</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>README.html</include>
+            </includes>
+        </fileSet>
 
-		<fileSet>
-			<directory>../opennlp-morfologik-addon/target/apidocs</directory>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>docs/apidocs/opennlp-morfologik-addon</outputDirectory>
-		</fileSet>
+        <fileSet>
+            <directory>target/issuesFixed</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>issuesFixed</outputDirectory>
+        </fileSet>
 
-		<fileSet>
-			<directory>../opennlp-uima/target/apidocs</directory>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>docs/apidocs/opennlp-uima</outputDirectory>
-		</fileSet>
-		
-		<fileSet>
-			<directory>../opennlp-uima/descriptors</directory>
-			<filtered>true</filtered>
-			<fileMode>644</fileMode>
-			<directoryMode>755</directoryMode>
-			<outputDirectory>docs/opennlp-uima-descriptors</outputDirectory>
-		</fileSet>
-		
-	</fileSets>
+        <fileSet>
+            <directory>src/main/bin</directory>
+            <fileMode>755</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>bin</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-morfologik-addon/src/main/bin</directory>
+            <fileMode>755</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>bin</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-brat-annotator/src/main/bin</directory>
+            <fileMode>755</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>bin</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-tools/lang</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>lang</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-docs/target/docbkx/html</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>docs/manual</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-tools/target/apidocs</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>docs/apidocs/opennlp-tools</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-brat-annotator/target/apidocs</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>docs/apidocs/opennlp-brat-annotator</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-morfologik-addon/target/apidocs</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>docs/apidocs/opennlp-morfologik-addon</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-uima/target/apidocs</directory>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>docs/apidocs/opennlp-uima</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>../opennlp-uima/descriptors</directory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+            <directoryMode>755</directoryMode>
+            <outputDirectory>docs/opennlp-uima-descriptors</outputDirectory>
+        </fileSet>
+
+    </fileSets>
 </assembly>

--- a/opennlp-distr/src/main/bin/opennlp
+++ b/opennlp-distr/src/main/bin/opennlp
@@ -37,4 +37,4 @@ fi
 # Might fail if $0 is a link
 OPENNLP_HOME=`dirname "$0"`/..
 
-$JAVACMD $HEAP -cp $(echo $OPENNLP_HOME/lib/*.jar | tr ' ' ':') opennlp.tools.cmdline.CLI $@
+$JAVACMD $HEAP -Dlog4j.configurationFile=../conf/log4j2.xml -cp $(echo $OPENNLP_HOME/lib/*.jar | tr ' ' ':') opennlp.tools.cmdline.CLI $@

--- a/opennlp-distr/src/main/bin/opennlp.bat
+++ b/opennlp-distr/src/main/bin/opennlp.bat
@@ -48,6 +48,6 @@ IF "%OPENNLP_HOME%" == "" (
 REM #  Get the library JAR file name (JIRA OPENNLP-554)
 FOR %%A IN ("%OPENNLP_HOME%\lib\opennlp-tools-*.jar") DO SET JAR_FILE=%%A
 
-%JAVA_CMD% %HEAP% -jar %JAR_FILE% %*
+%JAVA_CMD% %HEAP% "-Dlog4j.configurationFile=%OPENNLP_HOME%\conf\log4j2.xml" -jar %JAR_FILE% %*
 
 ENDLOCAL

--- a/opennlp-distr/src/main/resources/log4j2.xml
+++ b/opennlp-distr/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <!--
+                The pattern can be adjusted as needed, see https://logging.apache.org/log4j/2.x/manual/layouts.html
+            -->
+            <PatternLayout pattern="%m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Root level="DEBUG">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/opennlp-dl/pom.xml
+++ b/opennlp-dl/pom.xml
@@ -43,6 +43,10 @@
       <version>${onnxruntime.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -50,6 +54,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/opennlp-dl/src/main/java/opennlp/dl/doccat/DocumentCategorizerDL.java
+++ b/opennlp-dl/src/main/java/opennlp/dl/doccat/DocumentCategorizerDL.java
@@ -37,6 +37,8 @@ import ai.onnxruntime.OnnxTensor;
 import ai.onnxruntime.OrtEnvironment;
 import ai.onnxruntime.OrtException;
 import ai.onnxruntime.OrtSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.dl.InferenceOptions;
 import opennlp.dl.Tokens;
@@ -51,6 +53,7 @@ import opennlp.tools.tokenize.WordpieceTokenizer;
  */
 public class DocumentCategorizerDL implements DocumentCategorizer {
 
+  private static final Logger logger = LoggerFactory.getLogger(DocumentCategorizerDL.class);
   public static final String INPUT_IDS = "input_ids";
   public static final String ATTENTION_MASK = "attention_mask";
   public static final String TOKEN_TYPE_IDS = "token_type_ids";
@@ -132,7 +135,7 @@ public class DocumentCategorizerDL implements DocumentCategorizer {
       return classificationScoringStrategy.score(scores);
 
     } catch (Exception ex) {
-      System.err.println("Unload to perform document classification inference: " + ex.getMessage());
+      logger.error("Unload to perform document classification inference", ex);
     }
 
     return new double[]{};

--- a/opennlp-dl/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
+++ b/opennlp-dl/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
@@ -29,12 +29,16 @@ import ai.onnxruntime.OrtException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.dl.AbstactDLTest;
 import opennlp.dl.InferenceOptions;
 import opennlp.dl.doccat.scoring.AverageClassificationScoringStrategy;
 
 public class DocumentCategorizerDLEval extends AbstactDLTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(DocumentCategorizerDLEval.class);
 
   @Test
   public void categorize() throws IOException, OrtException {
@@ -76,8 +80,8 @@ public class DocumentCategorizerDLEval extends AbstactDLTest {
         0.11939861625432968,
         0.03615010157227516};
 
-    System.out.println("Actual:   " + Arrays.toString(sortedResult));
-    System.out.println("Expected: " + Arrays.toString(expected));
+    logger.debug("Actual: {}", Arrays.toString(sortedResult));
+    logger.debug("Expected: {}", Arrays.toString(expected));
 
     Assertions.assertArrayEquals(expected, sortedResult, 0.0);
     Assertions.assertEquals(5, result.length);
@@ -106,7 +110,7 @@ public class DocumentCategorizerDLEval extends AbstactDLTest {
             new InferenceOptions());
 
     final double[] result = documentCategorizerDL.categorize(new String[]{"I am happy"});
-    System.out.println(Arrays.toString(result));
+    logger.debug(Arrays.toString(result));
 
     final double[] expected = new double[]
         {0.007819971069693565,

--- a/opennlp-dl/src/test/java/opennlp/dl/namefinder/NameFinderDLEval.java
+++ b/opennlp-dl/src/test/java/opennlp/dl/namefinder/NameFinderDLEval.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import ai.onnxruntime.OrtException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.dl.AbstactDLTest;
 import opennlp.tools.sentdetect.SentenceDetector;
@@ -33,6 +35,7 @@ import opennlp.tools.util.Span;
 
 public class NameFinderDLEval extends AbstactDLTest {
 
+  private static final Logger logger = LoggerFactory.getLogger(NameFinderDLEval.class);
   private final SentenceDetector sentenceDetector ;
 
   public NameFinderDLEval() throws IOException {
@@ -55,7 +58,7 @@ public class NameFinderDLEval extends AbstactDLTest {
     final Span[] spans = nameFinderDL.find(tokens);
 
     for (Span span : spans) {
-      System.out.println(span.toString());
+      logger.debug(span.toString());
     }
 
     Assertions.assertEquals(1, spans.length);
@@ -81,7 +84,7 @@ public class NameFinderDLEval extends AbstactDLTest {
     final Span[] spans = nameFinderDL.find(tokens);
 
     for (Span span : spans) {
-      System.out.println(span.toString());
+      logger.debug(span.toString());
     }
 
     Assertions.assertEquals(1, spans.length);
@@ -105,7 +108,7 @@ public class NameFinderDLEval extends AbstactDLTest {
     final Span[] spans = nameFinderDL.find(tokens);
 
     for (Span span : spans) {
-      System.out.println(span.toString());
+      logger.debug(span.toString());
     }
 
     Assertions.assertEquals(1, spans.length);
@@ -166,7 +169,7 @@ public class NameFinderDLEval extends AbstactDLTest {
     final Span[] spans = nameFinderDL.find(tokens);
 
     for (Span span : spans) {
-      System.out.println(span.toString());
+      logger.debug(span.toString());
     }
 
     Assertions.assertEquals(2, spans.length);

--- a/opennlp-morfologik-addon/pom.xml
+++ b/opennlp-morfologik-addon/pom.xml
@@ -41,11 +41,17 @@
 			<version>${morfologik.version}</version>
 			<scope>compile</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.carrot2</groupId>
 			<artifactId>morfologik-tools</artifactId>
 			<version>${morfologik.version}</version>
 			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>
@@ -69,6 +75,12 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/opennlp-morfologik-addon/src/main/bin/morfologik-addon
+++ b/opennlp-morfologik-addon/src/main/bin/morfologik-addon
@@ -32,4 +32,4 @@ fi
 # Might fail if $0 is a link
 OPENNLP_HOME=`dirname "$0"`/..
 
-$JAVACMD -Xmx1024m -cp "lib/*" opennlp.morfologik.cmdline.CLI $@
+$JAVACMD -Xmx1024m -Dlog4j.configurationFile=../conf/log4j2.xml -cp "lib/*" opennlp.morfologik.cmdline.CLI $@

--- a/opennlp-morfologik-addon/src/main/bin/morfologik-addon.bat
+++ b/opennlp-morfologik-addon/src/main/bin/morfologik-addon.bat
@@ -46,6 +46,6 @@ FOR %%A IN ("%OPENNLP_HOME%\lib\*.jar") DO (
 )
 set CLASSPATH=!CLASSPATH!"
 
-%JAVA_CMD% -Xmx1024m -cp %CLASSPATH% opennlp.morfologik.cmdline.CLI %*
+%JAVA_CMD% -Xmx1024m "-Dlog4j.configurationFile=%OPENNLP_HOME%\conf\log4j2.xml" -cp %CLASSPATH% opennlp.morfologik.cmdline.CLI %*
 
 ENDLOCAL

--- a/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/cmdline/CLI.java
+++ b/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/cmdline/CLI.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.morfologik.cmdline.builder.MorfologikDictionaryBuilderTool;
 import opennlp.morfologik.cmdline.builder.XMLDictionaryToTableTool;
 import opennlp.tools.cmdline.BasicCmdLineTool;
@@ -35,6 +38,7 @@ import opennlp.tools.util.Version;
 
 public final class CLI {
 
+  private static final Logger logger = LoggerFactory.getLogger(CLI.class);
   private static final String CMD = "opennlp-morfologik-addon";
 
   private static Map<String, CmdLineTool> toolLookupMap;
@@ -62,10 +66,8 @@ public final class CLI {
   }
 
   private static void usage() {
-    System.out.print("OpenNLP Morfologik Addon "
-        + Version.currentVersion().toString() + ". ");
-    System.out.println("Usage: " + CMD + " TOOL");
-    System.out.println("where TOOL is one of:");
+    logger.info("OpenNLP Morfologik Addon {}.", Version.currentVersion());
+    logger.info("Usage: {} TOOL", CMD);
 
     // distance of tool name from line start
     int numberOfSpaces = -1;
@@ -76,20 +78,22 @@ public final class CLI {
     }
     numberOfSpaces = numberOfSpaces + 4;
 
+    final StringBuilder sb = new StringBuilder("where TOOL is one of: \n\n");
     for (CmdLineTool tool : toolLookupMap.values()) {
 
-      System.out.print("  " + tool.getName());
+      sb.append("  " + tool.getName());
 
       for (int i = 0; i < StrictMath.abs(tool.getName().length()
           - numberOfSpaces); i++) {
-        System.out.print(" ");
+        sb.append(" ");
       }
 
-      System.out.println(tool.getShortDescription());
+      sb.append(tool.getShortDescription()).append("\n");
     }
+    logger.info(sb.toString());
 
-    System.out.println("All tools print help when invoked with help parameter");
-    System.out.println("Example: opennlp-morfologik-addon POSDictionaryBuilder help");
+    logger.info("All tools print help when invoked with help parameter");
+    logger.info("Example: opennlp-morfologik-addon POSDictionaryBuilder help");
   }
 
 
@@ -123,9 +127,9 @@ public final class CLI {
       if ((0 == toolArguments.length && tool.hasParams()) ||
           0 < toolArguments.length && "help".equals(toolArguments[0])) {
         if (tool instanceof TypedCmdLineTool) {
-          System.out.println(((TypedCmdLineTool) tool).getHelp(formatName));
+          logger.info(((TypedCmdLineTool) tool).getHelp(formatName));
         } else if (tool instanceof BasicCmdLineTool) {
-          System.out.println(tool.getHelp());
+          logger.info(tool.getHelp());
         }
 
         System.exit(0);
@@ -143,16 +147,7 @@ public final class CLI {
         throw new TerminateToolException(1, "Tool " + toolName + " is not supported.");
       }
     } catch (TerminateToolException e) {
-
-      if (e.getMessage() != null) {
-        System.err.println(e.getMessage());
-      }
-
-      if (e.getCause() != null) {
-        System.err.println(e.getCause().getMessage());
-        e.getCause().printStackTrace(System.err);
-      }
-
+      logger.error(e.getLocalizedMessage(), e);
       System.exit(e.getCode());
     }
   }

--- a/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/cmdline/builder/XMLDictionaryToTableTool.java
+++ b/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/cmdline/builder/XMLDictionaryToTableTool.java
@@ -28,6 +28,8 @@ import java.util.Iterator;
 import java.util.Properties;
 
 import morfologik.stemming.DictionaryMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -36,6 +38,7 @@ import opennlp.tools.postag.POSDictionary;
 
 public class XMLDictionaryToTableTool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(XMLDictionaryToTableTool.class);
   private static String SEPARATOR;
 
   public String getShortDescription() {
@@ -80,7 +83,7 @@ public class XMLDictionaryToTableTool extends BasicCmdLineTool {
           }
         }
       }
-      System.out.println("Created dictionary: " + dictOutFile.toPath());
+      logger.info("Created dictionary: {}", dictOutFile.toPath());
     } catch (IOException e) {
       throw new TerminateToolException(-1, "Error while writing output: "
           + e.getMessage(), e);
@@ -99,15 +102,13 @@ public class XMLDictionaryToTableTool extends BasicCmdLineTool {
       throw new TerminateToolException(-1, "Error while writing metadata output: "
           + e.getMessage(), e);
     }
-    System.out.println("Created metadata: " + dictOutFile.toPath());
+    logger.info("Created metadata: {}", dictOutFile.toPath());
 
   }
 
   private boolean valid(String word, String tag) {
     if (word.contains(SEPARATOR) || tag.contains(SEPARATOR)) {
-      System.out
-          .println("Warn: invalid entry because contains separator - word: "
-              + word + " tag: " + tag);
+      logger.warn("invalid entry because contains separator - word: {} tag: {}", word, tag);
       return false;
     }
 

--- a/opennlp-tools/pom.xml
+++ b/opennlp-tools/pom.xml
@@ -35,6 +35,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -66,6 +71,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -128,7 +138,7 @@
               <artifactId>maven-surefire-plugin</artifactId>
               <version>${maven.surefire.plugin}</version>
               <configuration>
-                <argLine>-Xmx2048m -Djava.security.manager=allow</argLine>
+                <argLine>-Xmx2048m -Djava.security.manager=allow -Dorg.slf4j.simpleLogger.defaultLogLevel=off</argLine>
                 <forkCount>${opennlp.forkCount}</forkCount>
                 <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
                 <excludes>

--- a/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/chunker/ChunkSampleStream.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.FilterObjectStream;
 import opennlp.tools.util.ObjectStream;
 
@@ -32,6 +35,8 @@ import opennlp.tools.util.ObjectStream;
  * http://www.cnts.ua.ac.be/conll2000/chunking/</a>
  */
 public class ChunkSampleStream extends FilterObjectStream<String, ChunkSample> {
+
+  private static final Logger logger = LoggerFactory.getLogger(ChunkSampleStream.class);
 
   /**
    * Initializes a {@link ChunkSampleStream instance}.
@@ -52,7 +57,7 @@ public class ChunkSampleStream extends FilterObjectStream<String, ChunkSample> {
     for (String line = samples.read(); line != null && !line.equals(""); line = samples.read()) {
       String[] parts = line.split(" ");
       if (parts.length != 3) {
-        System.err.println("Skipping corrupt line: " + line);
+        logger.error("Skipping corrupt line: {}", line);
       }
       else {
         toks.add(parts[0]);

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/AbstractConverterTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/AbstractConverterTool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline;
 import java.io.IOException;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.ObjectStream;
 
 /**
@@ -29,6 +32,8 @@ import opennlp.tools.util.ObjectStream;
  *           for example {@link opennlp.tools.postag.POSSample}
  */
 public abstract class AbstractConverterTool<T,P> extends TypedCmdLineTool<T,P> {
+
+  private static final Logger logger = LoggerFactory.getLogger(AbstractConverterTool.class);
 
   /**
    * Constructor with type parameter.
@@ -88,7 +93,7 @@ public abstract class AbstractConverterTool<T,P> extends TypedCmdLineTool<T,P> {
   @Override
   public void run(String format, String[] args) {
     if (0 == args.length) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
       format = args[0];
       ObjectStreamFactory<T,P> streamFactory = getStreamFactory(format);
@@ -98,7 +103,7 @@ public abstract class AbstractConverterTool<T,P> extends TypedCmdLineTool<T,P> {
 
       String helpString = createHelpString(format, ArgumentParser.createUsage(streamFactory.getParameters()));
       if (0 == formatArgs.length || (1 == formatArgs.length && "help".equals(formatArgs[0]))) {
-        System.out.println(helpString);
+        logger.info(helpString);
         System.exit(0);
       }
 
@@ -110,7 +115,7 @@ public abstract class AbstractConverterTool<T,P> extends TypedCmdLineTool<T,P> {
       try (ObjectStream<T> sampleStream = streamFactory.create(formatArgs)) {
         Object sample;
         while ((sample = sampleStream.read()) != null) {
-          System.out.println(sample);
+          logger.info(sample.toString());
         }
       }
       catch (IOException e) {

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/CLI.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/CLI.java
@@ -25,6 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.chunker.ChunkerConverterTool;
 import opennlp.tools.cmdline.chunker.ChunkerCrossValidatorTool;
 import opennlp.tools.cmdline.chunker.ChunkerEvaluatorTool;
@@ -78,6 +81,8 @@ import opennlp.tools.cmdline.tokenizer.TokenizerTrainerTool;
 import opennlp.tools.util.Version;
 
 public final class CLI {
+
+  private static final Logger logger = LoggerFactory.getLogger(CLI.class);
 
   public static final String CMD = "opennlp";
 
@@ -186,9 +191,8 @@ public final class CLI {
   }
 
   private static void usage() {
-    System.out.print("OpenNLP " + Version.currentVersion() + ". ");
-    System.out.println("Usage: " + CMD + " TOOL");
-    System.out.println("where TOOL is one of:");
+    logger.info("OpenNLP {}.", Version.currentVersion() );
+    logger.info("Usage: {} TOOL", CMD);
 
     // distance of tool name from line start
     int numberOfSpaces = -1;
@@ -199,19 +203,21 @@ public final class CLI {
     }
     numberOfSpaces = numberOfSpaces + 4;
 
+    final StringBuilder sb = new StringBuilder("where TOOL is one of: \n\n");
     for (CmdLineTool tool : toolLookupMap.values()) {
 
-      System.out.print("  " + tool.getName());
+      sb.append("  ").append(tool.getName());
 
       for (int i = 0; i < StrictMath.abs(tool.getName().length() - numberOfSpaces); i++) {
-        System.out.print(" ");
+        sb.append(" ");
       }
 
-      System.out.println(tool.getShortDescription());
+      sb.append(tool.getShortDescription()).append("\n");
     }
+    logger.info(sb.toString());
 
-    System.out.println("All tools print help when invoked with help parameter");
-    System.out.println("Example: opennlp SimpleTokenizer help");
+    logger.info("All tools print help when invoked with help parameter");
+    logger.info("Example: opennlp SimpleTokenizer help");
   }
 
   public static void main(String[] args) {
@@ -244,9 +250,9 @@ public final class CLI {
       if ((0 == toolArguments.length && tool.hasParams()) ||
           0 < toolArguments.length && "help".equals(toolArguments[0])) {
         if (tool instanceof TypedCmdLineTool) {
-          System.out.println(((TypedCmdLineTool<?,?>) tool).getHelp(formatName));
+          logger.info(((TypedCmdLineTool<?,?>) tool).getHelp(formatName));
         } else if (tool instanceof BasicCmdLineTool) {
-          System.out.println(tool.getHelp());
+          logger.info(tool.getHelp());
         }
 
         System.exit(0);
@@ -265,20 +271,11 @@ public final class CLI {
       }
     }
     catch (TerminateToolException e) {
-
-      if (e.getMessage() != null) {
-        System.err.println(e.getMessage());
-      }
-
-      if (e.getCause() != null) {
-        System.err.println(e.getCause().getMessage());
-        e.getCause().printStackTrace(System.err);
-      }
-
+      logger.error(e.getLocalizedMessage(), e);
       System.exit(e.getCode());
     }
 
     final long endTime = System.currentTimeMillis();
-    System.err.format("Execution time: %.3f seconds\n", (endTime - startTime) / 1000.0);
+    logger.info(String.format("Execution time: %.3f seconds\n", (endTime - startTime) / 1000.0));
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/CmdLineUtil.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/CmdLineUtil.java
@@ -31,6 +31,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.commons.Internal;
 import opennlp.tools.ml.TrainerFactory;
 import opennlp.tools.util.InputStreamFactory;
@@ -45,6 +48,8 @@ import opennlp.tools.util.model.BaseModel;
  */
 @Internal
 public final class CmdLineUtil {
+
+  private static final Logger logger = LoggerFactory.getLogger(CmdLineUtil.class);
 
   static final int IO_BUFFER_SIZE = 1024 * 1024;
 
@@ -176,7 +181,7 @@ public final class CmdLineUtil {
 
     CmdLineUtil.checkOutputFile(modelName + " model", modelFile);
 
-    System.err.print("Writing " + modelName + " model ... ");
+    logger.info("Writing {} model ... ", modelName);
 
     long beginModelWritingTime = System.currentTimeMillis();
 
@@ -184,20 +189,14 @@ public final class CmdLineUtil {
         new FileOutputStream(modelFile), IO_BUFFER_SIZE)) {
       model.serialize(modelOut);
     } catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "Error during writing model file '" + modelFile + "'", e);
     }
 
     long modelWritingDuration = System.currentTimeMillis() - beginModelWritingTime;
 
-    System.err.printf("done (%.3fs)\n", modelWritingDuration / 1000d);
+    logger.info(String.format("done (%.3fs)\n", modelWritingDuration / 1000d));
 
-    System.err.println();
-
-    System.err.println("Wrote " + modelName + " model to");
-    System.err.println("path: " + modelFile.getAbsolutePath());
-
-    System.err.println();
+    logger.info("Wrote {} model to path: {}", modelName, modelFile.getAbsolutePath());
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/EvaluationErrorPrinter.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/EvaluationErrorPrinter.java
@@ -36,7 +36,11 @@ public abstract class EvaluationErrorPrinter<T> implements EvaluationMonitor<T> 
   protected PrintStream printStream;
 
   protected EvaluationErrorPrinter(OutputStream outputStream) {
-    this.printStream = new PrintStream(outputStream);
+    this(new PrintStream(outputStream));
+  }
+
+  protected EvaluationErrorPrinter(PrintStream printStream) {
+    this.printStream = printStream;
   }
 
   // for the sentence detector

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/GenerateManualTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/GenerateManualTool.java
@@ -28,16 +28,21 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.ArgumentParser.Argument;
 
 public class GenerateManualTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(GenerateManualTool.class);
 
   private static final int MAX_LINE_LENGTH = 110; // optimized for printing
 
   public static void main(String[] args) throws FileNotFoundException {
 
     if (args.length != 1) {
-      System.out.print(getUsage());
+      logger.info(getUsage());
       System.exit(0);
     }
 

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/ModelLoader.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/ModelLoader.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.commons.Internal;
 import opennlp.tools.util.InvalidFormatException;
 
@@ -35,6 +38,8 @@ import opennlp.tools.util.InvalidFormatException;
  */
 @Internal
 public abstract class ModelLoader<T> {
+
+  private static final Logger logger = LoggerFactory.getLogger(ModelLoader.class);
 
   private final String modelName;
 
@@ -50,7 +55,7 @@ public abstract class ModelLoader<T> {
 
     CmdLineUtil.checkInputFile(modelName + " model", modelFile);
 
-    System.err.print("Loading " + modelName + " model ... ");
+    logger.info("Loading {} model ... ", modelName);
 
     T model;
     try (InputStream modelIn = new BufferedInputStream(
@@ -58,17 +63,15 @@ public abstract class ModelLoader<T> {
       model = loadModel(modelIn);
     }
     catch (InvalidFormatException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "Model has invalid format", e);
     }
     catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while loading model file '" + modelFile + "'", e);
     }
 
     long modelLoadingDuration = System.currentTimeMillis() - beginModelLoadingTime;
 
-    System.err.printf("done (%.3fs)\n", modelLoadingDuration / 1000d);
+    logger.info(String.format("done (%.3fs)\n", modelLoadingDuration / 1000d));
 
     return model;
   }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/PerformanceMonitor.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/PerformanceMonitor.java
@@ -24,7 +24,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.commons.Internal;
+import opennlp.tools.log.LogPrintStream;
 
 /**
  * The {@link PerformanceMonitor} measures increments to a counter.
@@ -38,6 +42,8 @@ import opennlp.tools.commons.Internal;
  */
 @Internal
 public class PerformanceMonitor {
+
+  private static final Logger logger = LoggerFactory.getLogger(PerformanceMonitor.class);
 
   private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, runnable -> {
     Thread thread = new Thread(runnable);
@@ -62,7 +68,7 @@ public class PerformanceMonitor {
   }
 
   public PerformanceMonitor(String unit) {
-    this(System.out, unit);
+    this(new LogPrintStream(logger), unit);
   }
 
   public boolean isStarted() {
@@ -161,9 +167,6 @@ public class PerformanceMonitor {
     else {
       average = 0;
     }
-
-    out.println();
-    out.println();
 
     out.printf("Average: %.1f " + unit + "/s %n", average);
     out.println("Total: " + counter + " " + unit);

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkEvaluationErrorListener.java
@@ -19,9 +19,13 @@ package opennlp.tools.cmdline.chunker;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.chunker.ChunkSample;
 import opennlp.tools.chunker.ChunkerEvaluationMonitor;
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.util.eval.EvaluationMonitor;
 
 /**
@@ -32,11 +36,12 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class ChunkEvaluationErrorListener extends
     EvaluationErrorPrinter<ChunkSample> implements ChunkerEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(ChunkEvaluationErrorListener.class);
   /**
-   * Creates a listener that will print to {@code System.err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public ChunkEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkerCrossValidatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkerCrossValidatorTool.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.chunker.ChunkSample;
 import opennlp.tools.chunker.ChunkerCrossValidator;
 import opennlp.tools.chunker.ChunkerEvaluationMonitor;
@@ -34,11 +37,14 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 import opennlp.tools.util.eval.FMeasure;
 import opennlp.tools.util.model.ModelUtil;
 
+
 public final class ChunkerCrossValidatorTool
     extends AbstractCrossValidatorTool<ChunkSample, CVToolParams> {
 
   interface CVToolParams extends TrainingParams, CVParams, DetailedFMeasureEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(ChunkerCrossValidatorTool.class);
 
   public ChunkerCrossValidatorTool() {
     super(ChunkSample.class, CVToolParams.class);
@@ -92,9 +98,9 @@ public final class ChunkerCrossValidatorTool
 
     if (detailedFMeasureListener == null) {
       FMeasure result = validator.getFMeasure();
-      System.out.println(result);
+      logger.info(result.toString());
     } else {
-      System.out.println(detailedFMeasureListener);
+      logger.info(detailedFMeasureListener.toString());
     }
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkerEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkerEvaluatorTool.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.chunker.ChunkSample;
 import opennlp.tools.chunker.ChunkerEvaluationMonitor;
 import opennlp.tools.chunker.ChunkerEvaluator;
@@ -47,6 +50,8 @@ public final class ChunkerEvaluatorTool
 
   interface EvalToolParams extends EvaluatorParams, DetailedFMeasureEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(ChunkerEvaluatorTool.class);
 
   public ChunkerEvaluatorTool() {
     super(ChunkSample.class, EvalToolParams.class);
@@ -96,19 +101,16 @@ public final class ChunkerEvaluatorTool
       monitor.startAndPrintThroughput();
       evaluator.evaluate(measuredSampleStream);
     } catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while reading test data: " + e.getMessage(), e);
     }
     // sorry that this can fail
 
     monitor.stopAndPrintFinalResult();
 
-    System.out.println();
-
     if (detailedFMeasureListener == null) {
-      System.out.println(evaluator.getFMeasure());
+      logger.info(evaluator.getFMeasure().toString());
     } else {
-      System.out.println(detailedFMeasureListener);
+      logger.info(detailedFMeasureListener.toString());
     }
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkerMETool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/chunker/ChunkerMETool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline.chunker;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.chunker.ChunkSample;
 import opennlp.tools.chunker.ChunkerME;
 import opennlp.tools.chunker.ChunkerModel;
@@ -35,6 +38,8 @@ import opennlp.tools.util.PlainTextByLineStream;
 
 public class ChunkerMETool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(ChunkerMETool.class);
+
   @Override
   public String getShortDescription() {
     return "learnable chunker";
@@ -48,7 +53,7 @@ public class ChunkerMETool extends BasicCmdLineTool {
   @Override
   public void run(String[] args) {
     if (args.length != 1) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
       ChunkerModel model = new ChunkerModelLoader().load(new File(args[0]));
 
@@ -60,7 +65,7 @@ public class ChunkerMETool extends BasicCmdLineTool {
       try {
         lineStream = new PlainTextByLineStream(new SystemInputStreamFactory(),
             SystemInputStreamFactory.encoding());
-        perfMon = new PerformanceMonitor(System.err, "sent");
+        perfMon = new PerformanceMonitor("sent");
         perfMon.start();
         String line;
         while ((line = lineStream.read()) != null) {
@@ -69,14 +74,13 @@ public class ChunkerMETool extends BasicCmdLineTool {
           try {
             posSample = POSSample.parse(line);
           } catch (InvalidFormatException e) {
-            System.err.println("Invalid format:");
-            System.err.println(line);
+            logger.warn("Invalid format: {}", line, e);
             continue;
           }
 
           String[] chunks = chunker.chunk(posSample.getSentence(), posSample.getTags());
 
-          System.out.println(new ChunkSample(posSample.getSentence(),
+          logger.info(new ChunkSample(posSample.getSentence(),
               posSample.getTags(), chunks).nicePrint());
 
           perfMon.incrementCounter();

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatCrossValidatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatCrossValidatorTool.java
@@ -25,6 +25,9 @@ import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractCrossValidatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.TerminateToolException;
@@ -44,6 +47,8 @@ public final class DoccatCrossValidatorTool extends
 
   interface CVToolParams extends CVParams, TrainingParams, FineGrainedEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(DoccatCrossValidatorTool.class);
 
   public DoccatCrossValidatorTool() {
     super(DocumentSample.class, CVToolParams.class);
@@ -106,11 +111,11 @@ public final class DoccatCrossValidatorTool extends
       }
     }
 
-    System.out.println("done");
+    logger.info("done");
 
     if (reportListener != null) {
-      System.out.println("Writing fine-grained report to "
-          + params.getReportOutputFile().getAbsolutePath());
+      logger.info("Writing fine-grained report to {}",
+          params.getReportOutputFile().getAbsolutePath());
       reportListener.writeReport();
 
       try {
@@ -121,9 +126,7 @@ public final class DoccatCrossValidatorTool extends
       }
     }
 
-    System.out.println();
-
-    System.out.println("Accuracy: " + validator.getDocumentAccuracy() + "\n" +
-        "Number of documents: " + validator.getDocumentCount());
+    logger.info("Accuracy: {}, Number of documents: {}",
+            validator.getDocumentAccuracy(), validator.getDocumentAccuracy());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatEvaluationErrorListener.java
@@ -19,9 +19,13 @@ package opennlp.tools.cmdline.doccat;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
 import opennlp.tools.doccat.DoccatEvaluationMonitor;
 import opennlp.tools.doccat.DocumentSample;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.util.eval.EvaluationMonitor;
 
 /**
@@ -31,11 +35,13 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class DoccatEvaluationErrorListener extends
     EvaluationErrorPrinter<DocumentSample> implements DoccatEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(DoccatEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to System.err
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public DoccatEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatEvaluatorTool.java
@@ -25,6 +25,9 @@ import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.PerformanceMonitor;
@@ -52,6 +55,8 @@ public final class DoccatEvaluatorTool extends
 
   interface EvalToolParams extends EvaluatorParams, FineGrainedEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(DoccatEvaluatorTool.class);
 
   public DoccatEvaluatorTool() {
     super(DocumentSample.class, EvalToolParams.class);
@@ -116,7 +121,6 @@ public final class DoccatEvaluatorTool extends
       monitor.startAndPrintThroughput();
       evaluator.evaluate(measuredSampleStream);
     } catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while reading test data: "
               + e.getMessage(), e);
     }
@@ -124,13 +128,11 @@ public final class DoccatEvaluatorTool extends
 
     monitor.stopAndPrintFinalResult();
 
-    System.out.println();
-
-    System.out.println(evaluator);
+    logger.info(evaluator.toString());
 
     if (reportListener != null) {
-      System.out.println("Writing fine-grained report to "
-          + params.getReportOutputFile().getAbsolutePath());
+      logger.info("Writing fine-grained report to {}",
+          params.getReportOutputFile().getAbsolutePath());
       reportListener.writeReport();
 
       try {

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatFineGrainedReportListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatFineGrainedReportListener.java
@@ -19,9 +19,13 @@ package opennlp.tools.cmdline.doccat;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.FineGrainedReportListener;
 import opennlp.tools.doccat.DoccatEvaluationMonitor;
 import opennlp.tools.doccat.DocumentSample;
+import opennlp.tools.log.LogPrintStream;
 
 /**
  * Generates a detailed report for the POS Tagger.
@@ -32,11 +36,13 @@ import opennlp.tools.doccat.DocumentSample;
 public class DoccatFineGrainedReportListener
     extends FineGrainedReportListener implements DoccatEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(DoccatFineGrainedReportListener.class);
+
   /**
-   * Creates a listener that will print to {@link System#err}
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public DoccatFineGrainedReportListener() {
-    this(System.err);
+    this(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/doccat/DoccatTool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline.doccat;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -35,6 +38,8 @@ import opennlp.tools.util.PlainTextByLineStream;
 
 public class DoccatTool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(DoccatTool.class);
+
   @Override
   public String getShortDescription() {
     return "learned document categorizer";
@@ -49,7 +54,7 @@ public class DoccatTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (0 == args.length) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       DoccatModel model = new DoccatModelLoader().load(new File(args[0]));
@@ -61,7 +66,7 @@ public class DoccatTool extends BasicCmdLineTool {
        */
       ObjectStream<String> documentStream;
 
-      PerformanceMonitor perfMon = new PerformanceMonitor(System.err, "doc");
+      PerformanceMonitor perfMon = new PerformanceMonitor("doc");
       perfMon.start();
 
       try {
@@ -75,7 +80,7 @@ public class DoccatTool extends BasicCmdLineTool {
           String category = documentCategorizerME.getBestCategory(prob);
 
           DocumentSample sample = new DocumentSample(category, tokens);
-          System.out.println(sample);
+          logger.info(sample.toString());
 
           perfMon.incrementCounter();
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/entitylinker/EntityLinkerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/entitylinker/EntityLinkerTool.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -38,6 +41,8 @@ import opennlp.tools.util.Span;
 
 public class EntityLinkerTool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(EntityLinkerTool.class);
+
   @Override
   public String getShortDescription() {
     return "links an entity to an external data set";
@@ -47,7 +52,7 @@ public class EntityLinkerTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (0 == args.length) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     }
     else {
       // TODO: Ask Mark if we can remove the type, the user knows upfront if s/he tries
@@ -76,7 +81,7 @@ public class EntityLinkerTool extends BasicCmdLineTool {
         throw new TerminateToolException(-1, "Failed to instantiate the Entity Linker: " + e.getMessage());
       }
 
-      PerformanceMonitor perfMon = new PerformanceMonitor(System.err, "sent");
+      PerformanceMonitor perfMon = new PerformanceMonitor("sent");
       perfMon.start();
 
       try (ObjectStream<String> untokenizedLineStream = new PlainTextByLineStream(
@@ -123,7 +128,7 @@ public class EntityLinkerTool extends BasicCmdLineTool {
                 entityLinker.find(text.toString(), sentences, tokensBySentence, namesBySentence);
 
             for (Span linkedSpan : linkedSpans) {
-              System.out.println(linkedSpan);
+              logger.info(linkedSpan.toString());
             }
 
             perfMon.incrementCounter(document.size());

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorCrossValidatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorCrossValidatorTool.java
@@ -25,6 +25,9 @@ import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractCrossValidatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.TerminateToolException;
@@ -43,6 +46,8 @@ public final class LanguageDetectorCrossValidatorTool extends
 
   interface CVToolParams extends CVParams, TrainingParams, FineGrainedEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(LanguageDetectorCrossValidatorTool.class);
 
   public LanguageDetectorCrossValidatorTool() {
     super(LanguageSample.class, CVToolParams.class);
@@ -102,11 +107,11 @@ public final class LanguageDetectorCrossValidatorTool extends
       }
     }
 
-    System.out.println("done");
+    logger.info("done");
 
     if (reportListener != null) {
-      System.out.println("Writing fine-grained report to "
-          + params.getReportOutputFile().getAbsolutePath());
+      logger.info("Writing fine-grained report to {}",
+          params.getReportOutputFile().getAbsolutePath());
       reportListener.writeReport();
 
       try {
@@ -117,9 +122,7 @@ public final class LanguageDetectorCrossValidatorTool extends
       }
     }
 
-    System.out.println();
-
-    System.out.println("Accuracy: " + validator.getDocumentAccuracy() + "\n" +
-        "Number of documents: " + validator.getDocumentCount());
+    logger.info("Accuracy: {} Number of documents: {}",
+            validator.getDocumentAccuracy(), validator.getDocumentCount());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorEvaluationErrorListener.java
@@ -19,9 +19,13 @@ package opennlp.tools.cmdline.langdetect;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
 import opennlp.tools.langdetect.LanguageDetectorEvaluationMonitor;
 import opennlp.tools.langdetect.LanguageSample;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.util.eval.EvaluationMonitor;
 
 /**
@@ -31,11 +35,13 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class LanguageDetectorEvaluationErrorListener extends
     EvaluationErrorPrinter<LanguageSample> implements LanguageDetectorEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(LanguageDetectorEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to System.err
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public LanguageDetectorEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorEvaluatorTool.java
@@ -25,6 +25,9 @@ import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.PerformanceMonitor;
@@ -51,6 +54,9 @@ public final class LanguageDetectorEvaluatorTool extends
 
   interface EvalToolParams extends EvaluatorParams, FineGrainedEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(LanguageDetectorEvaluatorTool.class);
+
 
   public LanguageDetectorEvaluatorTool() {
     super(LanguageSample.class, EvalToolParams.class);
@@ -115,7 +121,6 @@ public final class LanguageDetectorEvaluatorTool extends
       monitor.startAndPrintThroughput();
       evaluator.evaluate(measuredSampleStream);
     } catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while reading test data: "
               + e.getMessage(), e);
     }
@@ -123,13 +128,11 @@ public final class LanguageDetectorEvaluatorTool extends
 
     monitor.stopAndPrintFinalResult();
 
-    System.out.println();
-
-    System.out.println(evaluator);
+    logger.info(evaluator.toString());
 
     if (reportListener != null) {
-      System.out.println("Writing fine-grained report to "
-          + params.getReportOutputFile().getAbsolutePath());
+      logger.info("Writing fine-grained report to {}",
+          params.getReportOutputFile().getAbsolutePath());
       reportListener.writeReport();
 
       try {

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/langdetect/LanguageDetectorTool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline.langdetect;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -36,6 +39,8 @@ import opennlp.tools.util.PlainTextByLineStream;
 
 public class LanguageDetectorTool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(LanguageDetectorTool.class);
+
   @Override
   public String getShortDescription() {
     return "learned language detector";
@@ -50,7 +55,7 @@ public class LanguageDetectorTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (0 == args.length) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       LanguageDetectorModel model = new LanguageDetectorModelLoader().load(new File(args[0]));
@@ -62,7 +67,7 @@ public class LanguageDetectorTool extends BasicCmdLineTool {
        */
       ObjectStream<String> documentStream;
 
-      PerformanceMonitor perfMon = new PerformanceMonitor(System.err, "doc");
+      PerformanceMonitor perfMon = new PerformanceMonitor("doc");
       perfMon.start();
 
       try {
@@ -74,7 +79,7 @@ public class LanguageDetectorTool extends BasicCmdLineTool {
           Language lang = langDetectME.predictLanguage(document);
 
           LanguageSample sample = new LanguageSample(lang, document);
-          System.out.println(sample);
+          logger.info(sample.toString());
 
           perfMon.incrementCounter();
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/languagemodel/NGramLanguageModelTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/languagemodel/NGramLanguageModelTool.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -36,6 +39,8 @@ import opennlp.tools.util.PlainTextByLineStream;
  * Command line tool for {@link opennlp.tools.languagemodel.NGramLanguageModel}.
  */
 public class NGramLanguageModelTool extends BasicCmdLineTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(NGramLanguageModelTool.class);
 
   @Override
   public String getShortDescription() {
@@ -55,7 +60,7 @@ public class NGramLanguageModelTool extends BasicCmdLineTool {
       try {
         lineStream = new PlainTextByLineStream(new SystemInputStreamFactory(),
                 SystemInputStreamFactory.encoding());
-        perfMon = new PerformanceMonitor(System.err, "nglm");
+        perfMon = new PerformanceMonitor("nglm");
         perfMon.start();
         String line;
         while ((line = lineStream.read()) != null) {
@@ -67,12 +72,11 @@ public class NGramLanguageModelTool extends BasicCmdLineTool {
             probability = nGramLanguageModel.calculateProbability(tokens);
             predicted = nGramLanguageModel.predictNextTokens(tokens);
           } catch (Exception e) {
-            System.err.println("Error:" + e.getLocalizedMessage());
-            System.err.println(line);
+            logger.error("Error for line: {}", line, e);
             continue;
           }
 
-          System.out.println(Arrays.toString(tokens) + " -> prob:" + probability + ", " +
+          logger.info(Arrays.toString(tokens) + " -> prob:" + probability + ", " +
                   "next:" + Arrays.toString(predicted));
 
           perfMon.incrementCounter();
@@ -84,7 +88,7 @@ public class NGramLanguageModelTool extends BasicCmdLineTool {
       perfMon.stopAndPrintFinalResult();
 
     } catch (IOException e) {
-      System.err.println(e.getLocalizedMessage());
+      logger.error(e.getLocalizedMessage(), e);
     }
     // do nothing
   }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmaEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmaEvaluationErrorListener.java
@@ -19,9 +19,13 @@ package opennlp.tools.cmdline.lemmatizer;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
 import opennlp.tools.lemmatizer.LemmaSample;
 import opennlp.tools.lemmatizer.LemmatizerEvaluationMonitor;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.util.eval.EvaluationMonitor;
 
 /**
@@ -31,11 +35,13 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class LemmaEvaluationErrorListener extends
     EvaluationErrorPrinter<LemmaSample> implements LemmatizerEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(LemmaEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to {@code System.err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public LemmaEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmatizerEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmatizerEvaluatorTool.java
@@ -23,6 +23,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.TerminateToolException;
@@ -42,6 +45,8 @@ import opennlp.tools.lemmatizer.LemmatizerModel;
  */
 public final class LemmatizerEvaluatorTool
     extends AbstractEvaluatorTool<LemmaSample, LemmatizerEvaluatorTool.EvalToolParams> {
+
+  private static final Logger logger = LoggerFactory.getLogger(LemmatizerEvaluatorTool.class);
 
   public LemmatizerEvaluatorTool() {
     super(LemmaSample.class, EvalToolParams.class);
@@ -83,11 +88,10 @@ public final class LemmatizerEvaluatorTool
         new opennlp.tools.lemmatizer.LemmatizerME(model),
         missclassifiedListener, reportListener);
 
-    System.out.print("Evaluating ... ");
+    logger.info("Evaluating ... ");
     try {
       evaluator.evaluate(sampleStream);
     } catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1,
           "IO error while reading test data: " + e.getMessage(), e);
     } finally {
@@ -98,11 +102,11 @@ public final class LemmatizerEvaluatorTool
       }
     }
 
-    System.out.println("done");
+    logger.info("done");
 
     if (reportListener != null) {
-      System.out.println("Writing fine-grained report to "
-          + params.getReportOutputFile().getAbsolutePath());
+      logger.info("Writing fine-grained report to {}",
+          params.getReportOutputFile().getAbsolutePath());
       reportListener.writeReport();
 
       try {
@@ -113,9 +117,7 @@ public final class LemmatizerEvaluatorTool
       }
     }
 
-    System.out.println();
-
-    System.out.println("Accuracy: " + evaluator.getWordAccuracy());
+    logger.info("Accuracy: {}", evaluator.getWordAccuracy());
   }
 
   interface EvalToolParams extends EvaluatorParams, FineGrainedEvaluatorParams {

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmatizerFineGrainedReportListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmatizerFineGrainedReportListener.java
@@ -19,9 +19,13 @@ package opennlp.tools.cmdline.lemmatizer;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.FineGrainedReportListener;
 import opennlp.tools.lemmatizer.LemmaSample;
 import opennlp.tools.lemmatizer.LemmatizerEvaluationMonitor;
+import opennlp.tools.log.LogPrintStream;
 
 /**
  * Generates a detailed report for the Lemmatizer.
@@ -32,11 +36,13 @@ import opennlp.tools.lemmatizer.LemmatizerEvaluationMonitor;
 public class LemmatizerFineGrainedReportListener
     extends FineGrainedReportListener implements LemmatizerEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(LemmatizerFineGrainedReportListener.class);
+
   /**
-   * Creates a listener that will print to {@code System#err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public LemmatizerFineGrainedReportListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmatizerMETool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/lemmatizer/LemmatizerMETool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline.lemmatizer;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -35,6 +38,8 @@ import opennlp.tools.util.PlainTextByLineStream;
 
 public class LemmatizerMETool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(LemmatizerMETool.class);
+
   public String getShortDescription() {
     return "learnable lemmatizer";
   }
@@ -47,7 +52,7 @@ public class LemmatizerMETool extends BasicCmdLineTool {
   @Override
   public void run(String[] args) {
     if (args.length != 1) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
       LemmatizerModel model = new LemmatizerModelLoader()
           .load(new File(args[0]));
@@ -60,7 +65,7 @@ public class LemmatizerMETool extends BasicCmdLineTool {
       try {
         lineStream = new PlainTextByLineStream(new SystemInputStreamFactory(),
             SystemInputStreamFactory.encoding());
-        perfMon = new PerformanceMonitor(System.err, "sent");
+        perfMon = new PerformanceMonitor("sent");
         perfMon.start();
         String line;
         while ((line = lineStream.read()) != null) {
@@ -69,16 +74,15 @@ public class LemmatizerMETool extends BasicCmdLineTool {
           try {
             posSample = POSSample.parse(line);
           } catch (InvalidFormatException e) {
-            System.err.println("Invalid format:");
-            System.err.println(line);
+            logger.warn("Invalid format: {}", line);
             continue;
           }
 
           String[] lemmas = lemmatizer.lemmatize(posSample.getSentence(),
               posSample.getTags());
 
-          System.out.println(new LemmaSample(posSample.getSentence(),
-              posSample.getTags(), lemmas));
+          logger.info(new LemmaSample(posSample.getSentence(),
+              posSample.getTags(), lemmas).toString());
 
           perfMon.incrementCounter();
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/CensusDictionaryCreatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/CensusDictionaryCreatorTool.java
@@ -23,6 +23,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.ArgumentParser.OptionalParameter;
 import opennlp.tools.cmdline.ArgumentParser.ParameterDescription;
 import opennlp.tools.cmdline.BasicCmdLineTool;
@@ -63,6 +66,8 @@ public class CensusDictionaryCreatorTool extends BasicCmdLineTool {
     @ParameterDescription(valueName = "dict")
     String getDict();
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(CensusDictionaryCreatorTool.class);
 
   public String getShortDescription() {
     return "Converts 1990 US Census names into a dictionary";
@@ -111,14 +116,14 @@ public class CensusDictionaryCreatorTool extends BasicCmdLineTool {
     Dictionary mDictionary;
     try (ObjectStream<StringList> sampleStream = new NameFinderCensus90NameStream(
             sampleDataIn, Charset.forName(params.getEncoding()))) {
-      System.out.println("Creating Dictionary...");
+      logger.info("Creating Dictionary...");
       mDictionary = createDictionary(sampleStream);
     } catch (IOException e) {
       throw new TerminateToolException(-1, "IO error while reading training data or indexing data: "
           + e.getMessage(), e);
     }
 
-    System.out.println("Saving Dictionary...");
+    logger.info("Saving Dictionary...");
 
     try (OutputStream out = new FileOutputStream(dictOutFile)) {
       mDictionary.serialize(out);

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/NameEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/NameEvaluationErrorListener.java
@@ -19,7 +19,11 @@ package opennlp.tools.cmdline.namefind;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.namefind.NameSample;
 import opennlp.tools.namefind.TokenNameFinderEvaluationMonitor;
 import opennlp.tools.util.eval.EvaluationMonitor;
@@ -31,11 +35,13 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class NameEvaluationErrorListener extends
     EvaluationErrorPrinter<NameSample> implements TokenNameFinderEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(NameEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to {@code System.err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public NameEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/NameSampleCountersStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/NameSampleCountersStream.java
@@ -22,6 +22,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.namefind.NameSample;
 import opennlp.tools.util.FilterObjectStream;
 import opennlp.tools.util.ObjectStream;
@@ -32,6 +35,8 @@ import opennlp.tools.util.Span;
  */
 public class NameSampleCountersStream
     extends FilterObjectStream<NameSample, NameSample> {
+
+  private static final Logger logger = LoggerFactory.getLogger(NameSampleCountersStream.class);
 
   private int sentenceCount;
   private int tokenCount;
@@ -87,13 +92,13 @@ public class NameSampleCountersStream
   }
 
   public void printSummary() {
-    System.out.println("Training data summary:");
-    System.out.println("#Sentences: " + getSentenceCount());
-    System.out.println("#Tokens: " + getTokenCount());
+    logger.info("Training data summary:");
+    logger.info("#Sentences: {}", getSentenceCount());
+    logger.info("#Tokens: {}", getTokenCount());
 
     int totalNames = 0;
     for (Map.Entry<String, Integer> counter : getNameCounters().entrySet()) {
-      System.out.println("#" + counter.getKey() + " entities: " + counter.getValue());
+      logger.info("#" + counter.getKey() + " entities: " + counter.getValue());
       totalNames += counter.getValue();
     }
   }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderCrossValidatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderCrossValidatorTool.java
@@ -26,6 +26,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractCrossValidatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.TerminateToolException;
@@ -51,6 +54,8 @@ public final class TokenNameFinderCrossValidatorTool
   interface CVToolParams extends TrainingParams, CVParams,
       DetailedFMeasureEvaluatorParams, FineGrainedEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(TokenNameFinderCrossValidatorTool.class);
 
   public TokenNameFinderCrossValidatorTool() {
     super(NameSample.class, CVToolParams.class);
@@ -155,17 +160,16 @@ public final class TokenNameFinderCrossValidatorTool
       }
     }
 
-    System.out.println("done");
-    System.out.println();
+    logger.info("done");
 
     if (reportFile != null) {
       reportListener.writeReport();
     }
 
     if (detailedFListener == null) {
-      System.out.println(validator.getFMeasure());
+      logger.info(validator.getFMeasure().toString());
     } else {
-      System.out.println(detailedFListener);
+      logger.info(detailedFListener.toString());
     }
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderEvaluatorTool.java
@@ -25,6 +25,9 @@ import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.ArgumentParser.OptionalParameter;
 import opennlp.tools.cmdline.ArgumentParser.ParameterDescription;
@@ -60,6 +63,8 @@ public final class TokenNameFinderEvaluatorTool
     @ParameterDescription(valueName = "types", description = "name types to use for evaluation")
     String getNameTypes();
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(TokenNameFinderEvaluatorTool.class);
 
   public TokenNameFinderEvaluatorTool() {
     super(NameSample.class, EvalToolParams.class);
@@ -136,23 +141,20 @@ public final class TokenNameFinderEvaluatorTool
       monitor.startAndPrintThroughput();
       evaluator.evaluate(measuredSampleStream);
     } catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while reading test data: " + e.getMessage(), e);
     }
     // sorry that this can fail
 
     monitor.stopAndPrintFinalResult();
 
-    System.out.println();
-
     if (reportFile != null) {
       reportListener.writeReport();
     }
 
     if (detailedFListener == null) {
-      System.out.println(evaluator.getFMeasure());
+      logger.info(evaluator.getFMeasure().toString());
     } else {
-      System.out.println(detailedFListener);
+      logger.info(detailedFListener.toString());
     }
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderFineGrainedReportListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderFineGrainedReportListener.java
@@ -21,7 +21,11 @@ import java.io.OutputStream;
 import java.util.Comparator;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.FineGrainedReportListener;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.namefind.NameSample;
 import opennlp.tools.namefind.TokenNameFinderEvaluationMonitor;
 import opennlp.tools.util.SequenceCodec;
@@ -35,13 +39,16 @@ import opennlp.tools.util.SequenceCodec;
 public class TokenNameFinderFineGrainedReportListener
     extends FineGrainedReportListener implements TokenNameFinderEvaluationMonitor {
 
+  private static final Logger logger =
+      LoggerFactory.getLogger(TokenNameFinderFineGrainedReportListener.class);
+
   private final SequenceCodec<String> sequenceCodec;
 
   /**
-   * Creates a listener that will print to {@code System#err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public TokenNameFinderFineGrainedReportListener(SequenceCodec<String> seqCodec) {
-    this(seqCodec, System.err);
+    this(seqCodec, new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderTool.java
@@ -23,6 +23,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -39,6 +42,8 @@ import opennlp.tools.util.Span;
 
 public final class TokenNameFinderTool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(TokenNameFinderTool.class);
+
   @Override
   public String getShortDescription() {
     return "learnable name finder";
@@ -53,7 +58,7 @@ public final class TokenNameFinderTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (args.length == 0) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       NameFinderME[] nameFinders = new NameFinderME[args.length];
@@ -66,7 +71,7 @@ public final class TokenNameFinderTool extends BasicCmdLineTool {
       // ObjectStream<String> untokenizedLineStream =
       // new PlainTextByLineStream(new InputStreamReader(System.in));
       ObjectStream<String> untokenizedLineStream;
-      PerformanceMonitor perfMon = new PerformanceMonitor(System.err, "sent");
+      PerformanceMonitor perfMon = new PerformanceMonitor("sent");
       perfMon.start();
 
       try {
@@ -99,7 +104,7 @@ public final class TokenNameFinderTool extends BasicCmdLineTool {
           NameSample nameSample = new NameSample(whitespaceTokenizerLine,
                   reducedNames, false);
 
-          System.out.println(nameSample);
+          logger.info(nameSample.toString());
 
           perfMon.incrementCounter();
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/namefind/TokenNameFinderTrainerTool.java
@@ -192,9 +192,7 @@ public final class TokenNameFinderTrainerTool
       }
     }
 
-    System.out.println();
     counters.printSummary();
-    System.out.println();
 
     CmdLineUtil.writeModel("name finder", modelOutFile, model);
 

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/BuildModelUpdaterTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/BuildModelUpdaterTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.parser;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.dictionary.Dictionary;
 import opennlp.tools.ml.EventTrainer;
 import opennlp.tools.ml.TrainerFactory;
@@ -32,6 +35,8 @@ import opennlp.tools.util.ObjectStream;
 import opennlp.tools.util.model.ModelUtil;
 
 public final class BuildModelUpdaterTool extends ModelUpdaterTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(BuildModelUpdaterTool.class);
 
   public String getShortDescription() {
     return "trains and updates the build model in a parser model";
@@ -48,7 +53,7 @@ public final class BuildModelUpdaterTool extends ModelUpdaterTool {
 
     // TODO: training individual models should be in the chunking parser, not here
     // Training build
-    System.out.println("Training builder");
+    logger.info("Training builder");
     ObjectStream<Event> bes = new ParserEventStream(parseSamples,
         originalModel.getHeadRules(), ParserEventTypeEnum.BUILD, mdict);
 

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/CheckModelUpdaterTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/CheckModelUpdaterTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.parser;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.dictionary.Dictionary;
 import opennlp.tools.ml.EventTrainer;
 import opennlp.tools.ml.TrainerFactory;
@@ -36,6 +39,8 @@ import opennlp.tools.util.model.ModelUtil;
  */
 public final class CheckModelUpdaterTool extends ModelUpdaterTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(CheckModelUpdaterTool.class);
+
   @Override
   public String getShortDescription() {
     return "trains and updates the check model in a parser model";
@@ -52,7 +57,7 @@ public final class CheckModelUpdaterTool extends ModelUpdaterTool {
 
     // TODO: Maybe that should be part of the ChunkingParser ...
     // Training build
-    System.out.println("Training check model");
+    logger.info("Training check model");
     ObjectStream<Event> bes = new ParserEventStream(parseSamples,
         originalModel.getHeadRules(), ParserEventTypeEnum.CHECK, mdict);
 

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserEvaluatorTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.parser;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.TerminateToolException;
 import opennlp.tools.cmdline.params.EvaluatorParams;
@@ -36,6 +39,8 @@ import opennlp.tools.parser.ParserModel;
  * @see EvaluatorParams
  */
 public class ParserEvaluatorTool extends AbstractEvaluatorTool<Parse, EvaluatorParams> {
+
+  private static final Logger logger = LoggerFactory.getLogger(ParserEvaluatorTool.class);
 
   public ParserEvaluatorTool() {
     super(Parse.class, EvaluatorParams.class);
@@ -57,12 +62,11 @@ public class ParserEvaluatorTool extends AbstractEvaluatorTool<Parse, EvaluatorP
 
     ParserEvaluator evaluator = new ParserEvaluator(parser);
 
-    System.out.print("Evaluating ... ");
+    logger.info("Evaluating ... ");
     try {
       evaluator.evaluate(sampleStream);
     }
     catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while reading test data: " + e.getMessage(), e);
     } finally {
       try {
@@ -71,9 +75,8 @@ public class ParserEvaluatorTool extends AbstractEvaluatorTool<Parse, EvaluatorP
         // sorry that this can fail
       }
     }
-    System.out.println("done");
-    System.out.println();
+    logger.info("done");
 
-    System.out.println(evaluator.getFMeasure());
+    logger.info(evaluator.getFMeasure().toString());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserTool.java
@@ -24,6 +24,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -44,6 +47,8 @@ import opennlp.tools.util.PlainTextByLineStream;
 import opennlp.tools.util.Span;
 
 public final class ParserTool extends BasicCmdLineTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(ParserTool.class);
 
   @Override
   public String getShortDescription() {
@@ -97,7 +102,7 @@ public final class ParserTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (args.length < 1) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       ParserModel model = new ParserModelLoader().load(new File(args[args.length - 1]));
@@ -136,18 +141,18 @@ public final class ParserTool extends BasicCmdLineTool {
       try {
         lineStream = new PlainTextByLineStream(new SystemInputStreamFactory(),
             SystemInputStreamFactory.encoding());
-        perfMon = new PerformanceMonitor(System.err, "sent");
+        perfMon = new PerformanceMonitor("sent");
         perfMon.start();
         String line;
         while ((line = lineStream.read()) != null) {
           if (line.trim().length() == 0) {
-            System.out.println();
+            logger.debug("empty line");
           } else {
             Parse[] parses = parseLine(line, parser, tokenizer, numParses);
 
             for (int pi = 0, pn = parses.length; pi < pn; pi++) {
               if (showTopK) {
-                System.out.print(pi + " " + parses[pi].getProb() + " ");
+                logger.debug(pi + " " + parses[pi].getProb() + " ");
               }
 
               parses[pi].show();

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/ParserTrainerTool.java
@@ -21,6 +21,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractTrainerTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.TerminateToolException;
@@ -44,6 +47,8 @@ public final class ParserTrainerTool extends AbstractTrainerTool<Parse, TrainerT
   interface TrainerToolParams extends TrainingParams, TrainingToolParams, EncodingParameter {
   }
 
+  private static final Logger logger = LoggerFactory.getLogger(ParserTrainerTool.class);
+
   public ParserTrainerTool() {
     super(Parse.class, TrainerToolParams.class);
   }
@@ -54,17 +59,17 @@ public final class ParserTrainerTool extends AbstractTrainerTool<Parse, TrainerT
   }
 
   static Dictionary buildDictionary(ObjectStream<Parse> parseSamples, HeadRules headRules, int cutoff) {
-    System.err.print("Building dictionary ...");
+    logger.info("Building dictionary ...");
 
     Dictionary mdict;
     try {
       mdict = Parser.
           buildDictionary(parseSamples, headRules, cutoff);
     } catch (IOException e) {
-      System.err.println("Error while building dictionary: " + e.getMessage());
+      logger.error("Error while building dictionary.", e);
       mdict = null;
     }
-    System.err.println("done");
+    logger.info("done");
 
     return mdict;
   }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/TaggerModelReplacerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/parser/TaggerModelReplacerTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.parser;
 
 import java.io.File;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -28,6 +31,8 @@ import opennlp.tools.postag.POSModel;
 
 // user should train with the POS tool
 public final class TaggerModelReplacerTool extends BasicCmdLineTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(TaggerModelReplacerTool.class);
 
   @Override
   public String getShortDescription() {
@@ -43,7 +48,7 @@ public final class TaggerModelReplacerTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (args.length != 2) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       File parserModelInFile = new File(args[0]);

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSEvaluationErrorListener.java
@@ -19,7 +19,11 @@ package opennlp.tools.cmdline.postag;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.postag.POSSample;
 import opennlp.tools.postag.POSTaggerEvaluationMonitor;
 import opennlp.tools.util.eval.EvaluationMonitor;
@@ -31,11 +35,13 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class POSEvaluationErrorListener extends
     EvaluationErrorPrinter<POSSample> implements POSTaggerEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(POSEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to {@code System.err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public POSEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerCrossValidatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerCrossValidatorTool.java
@@ -24,6 +24,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractCrossValidatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.TerminateToolException;
@@ -41,6 +44,8 @@ public final class POSTaggerCrossValidatorTool
 
   interface CVToolParams extends CVParams, TrainingParams, FineGrainedEvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(POSTaggerCrossValidatorTool.class);
 
   public POSTaggerCrossValidatorTool() {
     super(POSSample.class, CVToolParams.class);
@@ -108,11 +113,11 @@ public final class POSTaggerCrossValidatorTool
       }
     }
 
-    System.out.println("done");
+    logger.info("done");
 
     if (reportListener != null) {
-      System.out.println("Writing fine-grained report to "
-          + params.getReportOutputFile().getAbsolutePath());
+      logger.info("Writing fine-grained report to {}",
+          params.getReportOutputFile().getAbsolutePath());
       reportListener.writeReport();
 
       try {
@@ -123,8 +128,6 @@ public final class POSTaggerCrossValidatorTool
       }
     }
 
-    System.out.println();
-
-    System.out.println("Accuracy: " + validator.getWordAccuracy());
+    logger.info("Accuracy: {}", validator.getWordAccuracy());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerEvaluatorTool.java
@@ -23,6 +23,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.TerminateToolException;
@@ -34,6 +37,7 @@ import opennlp.tools.postag.POSModel;
 import opennlp.tools.postag.POSSample;
 import opennlp.tools.postag.POSTaggerEvaluationMonitor;
 
+
 /**
  * A default {@link POSSample}-centric implementation of {@link AbstractEvaluatorTool}
  * that prints to an output stream.
@@ -43,6 +47,8 @@ import opennlp.tools.postag.POSTaggerEvaluationMonitor;
  */
 public final class POSTaggerEvaluatorTool
     extends AbstractEvaluatorTool<POSSample, EvalToolParams> {
+
+  private static final Logger logger = LoggerFactory.getLogger(POSTaggerEvaluatorTool.class);
 
   interface EvalToolParams extends EvaluatorParams, FineGrainedEvaluatorParams {
   }
@@ -87,12 +93,11 @@ public final class POSTaggerEvaluatorTool
         new opennlp.tools.postag.POSTaggerME(model), missclassifiedListener,
         reportListener);
 
-    System.out.print("Evaluating ... ");
+    logger.info("Evaluating ... ");
     try {
       evaluator.evaluate(sampleStream);
     }
     catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while reading test data: " + e.getMessage(), e);
     } finally {
       try {
@@ -102,11 +107,11 @@ public final class POSTaggerEvaluatorTool
       }
     }
 
-    System.out.println("done");
+    logger.info("done");
 
     if (reportListener != null) {
-      System.out.println("Writing fine-grained report to "
-          + params.getReportOutputFile().getAbsolutePath());
+      logger.info("Writing fine-grained report to {}",
+          params.getReportOutputFile().getAbsolutePath());
       reportListener.writeReport();
 
       try {
@@ -117,8 +122,6 @@ public final class POSTaggerEvaluatorTool
       }
     }
 
-    System.out.println();
-
-    System.out.println("Accuracy: " + evaluator.getWordAccuracy());
+    logger.info("Accuracy: {}", evaluator.getWordAccuracy());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerFineGrainedReportListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerFineGrainedReportListener.java
@@ -19,7 +19,11 @@ package opennlp.tools.cmdline.postag;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.FineGrainedReportListener;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.postag.POSSample;
 import opennlp.tools.postag.POSTaggerEvaluationMonitor;
 
@@ -33,11 +37,13 @@ import opennlp.tools.postag.POSTaggerEvaluationMonitor;
 public class POSTaggerFineGrainedReportListener
     extends FineGrainedReportListener implements POSTaggerEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(POSTaggerFineGrainedReportListener.class);
+
   /**
-   * Creates a listener that will print to {@code System#err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public POSTaggerFineGrainedReportListener() {
-    this(System.err);
+    this(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/postag/POSTaggerTool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline.postag;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -33,6 +36,8 @@ import opennlp.tools.util.ObjectStream;
 import opennlp.tools.util.PlainTextByLineStream;
 
 public final class POSTaggerTool extends BasicCmdLineTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(POSTaggerTool.class);
 
   @Override
   public String getShortDescription() {
@@ -48,7 +53,7 @@ public final class POSTaggerTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (args.length != 1) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       POSModel model = new POSModelLoader().load(new File(args[0]));
@@ -61,7 +66,7 @@ public final class POSTaggerTool extends BasicCmdLineTool {
       try {
         lineStream =
             new PlainTextByLineStream(new SystemInputStreamFactory(), SystemInputStreamFactory.encoding());
-        perfMon = new PerformanceMonitor(System.err, "sent");
+        perfMon = new PerformanceMonitor("sent");
         perfMon.start();
         String line;
         while ((line = lineStream.read()) != null) {
@@ -70,7 +75,7 @@ public final class POSTaggerTool extends BasicCmdLineTool {
           String[] tags = tagger.tag(whitespaceTokenizerLine);
 
           POSSample sample = new POSSample(whitespaceTokenizerLine, tags);
-          System.out.println(sample);
+          logger.info(sample.toString());
 
           perfMon.incrementCounter();
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorCrossValidatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorCrossValidatorTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.sentdetect;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractCrossValidatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.params.CVParams;
@@ -34,6 +37,8 @@ import opennlp.tools.util.model.ModelUtil;
 
 public final class SentenceDetectorCrossValidatorTool
     extends AbstractCrossValidatorTool<SentenceSample, CVToolParams> {
+
+  private static final Logger logger = LoggerFactory.getLogger(SentenceDetectorCrossValidatorTool.class);
 
   interface CVToolParams extends TrainingParams, CVParams {
   }
@@ -91,6 +96,6 @@ public final class SentenceDetectorCrossValidatorTool
 
     FMeasure result = validator.getFMeasure();
 
-    System.out.println(result);
+    logger.info(result.toString());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorEvaluatorTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.sentdetect;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.TerminateToolException;
 import opennlp.tools.cmdline.params.EvaluatorParams;
@@ -41,6 +44,9 @@ public final class SentenceDetectorEvaluatorTool
 
   interface EvalToolParams extends EvaluatorParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(SentenceDetectorEvaluatorTool.class);
+
 
   public SentenceDetectorEvaluatorTool() {
     super(SentenceSample.class, EvalToolParams.class);
@@ -65,7 +71,7 @@ public final class SentenceDetectorEvaluatorTool
     SentenceDetectorEvaluator evaluator = new SentenceDetectorEvaluator(
         new SentenceDetectorME(model), errorListener);
 
-    System.out.print("Evaluating ... ");
+    logger.info("Evaluating ... ");
     try {
       evaluator.evaluate(sampleStream);
     }
@@ -81,9 +87,8 @@ public final class SentenceDetectorEvaluatorTool
       }
     }
 
-    System.err.println("done");
-    System.out.println();
+    logger.info("done");
 
-    System.out.println(evaluator.getFMeasure());
+    logger.info(evaluator.getFMeasure().toString());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceDetectorTool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline.sentdetect;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -35,6 +38,8 @@ import opennlp.tools.util.PlainTextByLineStream;
  * A sentence detector which uses a maxent model to predict the sentences.
  */
 public final class SentenceDetectorTool extends BasicCmdLineTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(SentenceDetectorTool.class);
 
   @Override
   public String getShortDescription() {
@@ -55,14 +60,14 @@ public final class SentenceDetectorTool extends BasicCmdLineTool {
   public void run(String[] args) {
 
     if (args.length != 1) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       SentenceModel model = new SentenceModelLoader().load(new File(args[0]));
 
       SentenceDetectorME sdetector = new SentenceDetectorME(model);
 
-      PerformanceMonitor perfMon = new PerformanceMonitor(System.err, "sent");
+      PerformanceMonitor perfMon = new PerformanceMonitor("sent");
       perfMon.start();
 
       try (ObjectStream<String> paraStream = new ParagraphStream(new PlainTextByLineStream(
@@ -73,12 +78,11 @@ public final class SentenceDetectorTool extends BasicCmdLineTool {
 
           String[] sents = sdetector.sentDetect(para);
           for (String sentence : sents) {
-            System.out.println(sentence);
+            logger.info(sentence);
           }
 
           perfMon.incrementCounter(sents.length);
 
-          System.out.println();
         }
       }
       catch (IOException e) {

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/sentdetect/SentenceEvaluationErrorListener.java
@@ -19,7 +19,11 @@ package opennlp.tools.cmdline.sentdetect;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.sentdetect.SentenceDetectorEvaluationMonitor;
 import opennlp.tools.sentdetect.SentenceSample;
 import opennlp.tools.util.eval.EvaluationMonitor;
@@ -32,11 +36,13 @@ public class SentenceEvaluationErrorListener extends
     EvaluationErrorPrinter<SentenceSample> implements
     SentenceDetectorEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(SentenceEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to {@code System.err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public SentenceEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/CommandLineTokenizer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/CommandLineTokenizer.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.tokenizer;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.PerformanceMonitor;
 import opennlp.tools.cmdline.SystemInputStreamFactory;
@@ -30,6 +33,7 @@ import opennlp.tools.util.PlainTextByLineStream;
 
 final class CommandLineTokenizer {
 
+  private static final Logger logger = LoggerFactory.getLogger(CommandLineTokenizer.class);
   private final Tokenizer tokenizer;
 
   CommandLineTokenizer(Tokenizer tokenizer) {
@@ -48,13 +52,13 @@ final class CommandLineTokenizer {
       tokenizedLineStream = new WhitespaceTokenStream(
               new TokenizerStream(tokenizer, untokenizedLineStream));
 
-      perfMon = new PerformanceMonitor(System.err, "sent");
+      perfMon = new PerformanceMonitor("sent");
       perfMon.start();
 
 
       String tokenizedLine;
       while ((tokenizedLine = tokenizedLineStream.read()) != null) {
-        System.out.println(tokenizedLine);
+        logger.info(tokenizedLine);
         perfMon.incrementCounter();
       }
     } catch (IOException e) {

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/DetokenEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/DetokenEvaluationErrorListener.java
@@ -19,7 +19,11 @@ package opennlp.tools.cmdline.tokenizer;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.tokenize.TokenSample;
 import opennlp.tools.tokenize.TokenizerEvaluationMonitor;
 import opennlp.tools.util.eval.EvaluationMonitor;
@@ -31,11 +35,13 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class DetokenEvaluationErrorListener extends
     EvaluationErrorPrinter<TokenSample> implements TokenizerEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(DetokenEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to {@code System.err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public DetokenEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/DictionaryDetokenizerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/DictionaryDetokenizerTool.java
@@ -20,6 +20,9 @@ package opennlp.tools.cmdline.tokenizer;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -33,6 +36,8 @@ import opennlp.tools.util.PlainTextByLineStream;
 
 public final class DictionaryDetokenizerTool extends BasicCmdLineTool {
 
+  private static final Logger logger = LoggerFactory.getLogger(DictionaryDetokenizerTool.class);
+
   @Override
   public String getHelp() {
     return "Usage: " + CLI.CMD + " " + getName() + " detokenizerDictionary";
@@ -41,7 +46,7 @@ public final class DictionaryDetokenizerTool extends BasicCmdLineTool {
   @Override
   public void run(String[] args) {
     if (args.length != 1) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
       try {
         Detokenizer detokenizer = new DictionaryDetokenizer(
@@ -50,7 +55,7 @@ public final class DictionaryDetokenizerTool extends BasicCmdLineTool {
         try (ObjectStream<String> tokenizedLineStream =
             new PlainTextByLineStream(new SystemInputStreamFactory(), SystemInputStreamFactory.encoding())) {
 
-          PerformanceMonitor perfMon = new PerformanceMonitor(System.err, "sent");
+          PerformanceMonitor perfMon = new PerformanceMonitor("sent");
           perfMon.start();
 
           String tokenizedLine;
@@ -59,7 +64,7 @@ public final class DictionaryDetokenizerTool extends BasicCmdLineTool {
             // white space tokenize line
             String[] tokens = WhitespaceTokenizer.INSTANCE.tokenize(tokenizedLine);
 
-            System.out.println(detokenizer.detokenize(tokens, null));
+            logger.info(detokenizer.detokenize(tokens, null));
 
             perfMon.incrementCounter();
           }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/SimpleTokenizerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/SimpleTokenizerTool.java
@@ -17,10 +17,15 @@
 
 package opennlp.tools.cmdline.tokenizer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 
 public final class SimpleTokenizerTool extends BasicCmdLineTool {
+
+  private static final Logger logger = LoggerFactory.getLogger(SimpleTokenizerTool.class);
 
   @Override
   public String getShortDescription() {
@@ -40,7 +45,7 @@ public final class SimpleTokenizerTool extends BasicCmdLineTool {
   @Override
   public void run(String[] args) {
     if (args.length != 0) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       CommandLineTokenizer tokenizer =

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenEvaluationErrorListener.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenEvaluationErrorListener.java
@@ -19,7 +19,11 @@ package opennlp.tools.cmdline.tokenizer;
 
 import java.io.OutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.EvaluationErrorPrinter;
+import opennlp.tools.log.LogPrintStream;
 import opennlp.tools.tokenize.TokenSample;
 import opennlp.tools.tokenize.TokenizerEvaluationMonitor;
 import opennlp.tools.util.eval.EvaluationMonitor;
@@ -31,11 +35,13 @@ import opennlp.tools.util.eval.EvaluationMonitor;
 public class TokenEvaluationErrorListener extends
     EvaluationErrorPrinter<TokenSample> implements TokenizerEvaluationMonitor {
 
+  private static final Logger logger = LoggerFactory.getLogger(TokenEvaluationErrorListener.class);
+
   /**
-   * Creates a listener that will print to {@code System.err}.
+   * Creates a listener that will print to the configured {@code logger}.
    */
   public TokenEvaluationErrorListener() {
-    super(System.err);
+    super(new LogPrintStream(logger));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerCrossValidatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerCrossValidatorTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.tokenizer;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractCrossValidatorTool;
 import opennlp.tools.cmdline.CmdLineUtil;
 import opennlp.tools.cmdline.params.CVParams;
@@ -36,6 +39,8 @@ public final class TokenizerCrossValidatorTool
 
   interface CVToolParams extends CVParams, TrainingParams {
   }
+
+  private static final Logger logger = LoggerFactory.getLogger(TokenizerCrossValidatorTool.class);
 
   public TokenizerCrossValidatorTool() {
     super(TokenSample.class, CVToolParams.class);
@@ -86,6 +91,6 @@ public final class TokenizerCrossValidatorTool
 
     FMeasure result = validator.getFMeasure();
 
-    System.out.println(result);
+    logger.info(result.toString());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerMEEvaluatorTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerMEEvaluatorTool.java
@@ -19,6 +19,9 @@ package opennlp.tools.cmdline.tokenizer;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.AbstractEvaluatorTool;
 import opennlp.tools.cmdline.TerminateToolException;
 import opennlp.tools.cmdline.params.EvaluatorParams;
@@ -37,6 +40,8 @@ import opennlp.tools.tokenize.TokenizerModel;
  */
 public final class TokenizerMEEvaluatorTool
     extends AbstractEvaluatorTool<TokenSample, EvalToolParams> {
+
+  private static final Logger logger = LoggerFactory.getLogger(TokenizerMEEvaluatorTool.class);
 
   interface EvalToolParams extends EvaluatorParams {
   }
@@ -64,12 +69,11 @@ public final class TokenizerMEEvaluatorTool
     TokenizerEvaluator evaluator = new TokenizerEvaluator(
         new opennlp.tools.tokenize.TokenizerME(model), misclassifiedListener);
 
-    System.out.print("Evaluating ... ");
+    logger.info("Evaluating ... ");
 
     try {
       evaluator.evaluate(sampleStream);
     } catch (IOException e) {
-      System.err.println("failed");
       throw new TerminateToolException(-1, "IO error while reading test data: " + e.getMessage(), e);
     } finally {
       try {
@@ -79,9 +83,8 @@ public final class TokenizerMEEvaluatorTool
       }
     }
 
-    System.out.println("done");
-    System.out.println();
+    logger.info("done");
 
-    System.out.println(evaluator.getFMeasure());
+    logger.info(evaluator.getFMeasure().toString());
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerMETool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerMETool.java
@@ -19,11 +19,15 @@ package opennlp.tools.cmdline.tokenizer;
 
 import java.io.File;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.cmdline.BasicCmdLineTool;
 import opennlp.tools.cmdline.CLI;
 import opennlp.tools.tokenize.TokenizerModel;
 
 public final class TokenizerMETool extends BasicCmdLineTool {
+  private static final Logger logger = LoggerFactory.getLogger(TokenizerMETool.class);
 
   @Override
   public String getShortDescription() {
@@ -38,7 +42,7 @@ public final class TokenizerMETool extends BasicCmdLineTool {
   @Override
   public void run(String[] args) {
     if (args.length != 1) {
-      System.out.println(getHelp());
+      logger.info(getHelp());
     } else {
 
       TokenizerModel model = new TokenizerModelLoader().load(new File(args[0]));

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/BioNLP2004NameSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/BioNLP2004NameSampleStream.java
@@ -18,7 +18,6 @@
 package opennlp.tools.formats;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +84,6 @@ public class BioNLP2004NameSampleStream implements ObjectStream<NameSample> {
    */
   public BioNLP2004NameSampleStream(InputStreamFactory in, int types) throws IOException {
     this.lineStream = new PlainTextByLineStream(in, StandardCharsets.UTF_8);
-    System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
     this.types = types;
   }
 

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/Conll02NameSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/Conll02NameSampleStream.java
@@ -18,7 +18,6 @@
 package opennlp.tools.formats;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,7 +92,6 @@ public class Conll02NameSampleStream implements ObjectStream<NameSample> {
    */
   public Conll02NameSampleStream(LANGUAGE lang, InputStreamFactory in, int types) throws IOException {
     this (lang, new PlainTextByLineStream(in, StandardCharsets.UTF_8), types);
-    System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
   }
 
   static Span extract(int begin, int end, String beginTag) throws InvalidFormatException {

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/Conll03NameSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/Conll03NameSampleStream.java
@@ -18,7 +18,6 @@
 package opennlp.tools.formats;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,7 +69,6 @@ public class Conll03NameSampleStream implements ObjectStream<NameSample> {
    */
   public Conll03NameSampleStream(LANGUAGE lang, InputStreamFactory in, int types) throws IOException {
     this(lang, new PlainTextByLineStream(in, StandardCharsets.UTF_8), types);
-    System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
   }
 
   @Override

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/ConllXPOSSampleStreamFactory.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/ConllXPOSSampleStreamFactory.java
@@ -18,7 +18,6 @@
 package opennlp.tools.formats;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
@@ -63,8 +62,6 @@ public class ConllXPOSSampleStreamFactory<P> extends AbstractSampleStreamFactory
         CmdLineUtil.createInputStreamFactory(params.getData());
 
     try {
-      System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
-
       return new ConllXPOSSampleStream(inFactory, StandardCharsets.UTF_8);
     } catch (UnsupportedEncodingException e) {
       // this shouldn't happen

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/EvalitaNameSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/EvalitaNameSampleStream.java
@@ -18,7 +18,6 @@
 package opennlp.tools.formats;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -84,7 +83,6 @@ public class EvalitaNameSampleStream implements ObjectStream<NameSample> {
 
   public EvalitaNameSampleStream(LANGUAGE lang, InputStreamFactory in, int types) throws IOException {
     this(lang, new PlainTextByLineStream(in, StandardCharsets.UTF_8),types);
-    System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
   }
 
   private static Span extract(int begin, int end, String beginTag) throws InvalidFormatException {

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/ad/ADSentenceStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/ad/ADSentenceStream.java
@@ -26,6 +26,9 @@ import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.commons.Internal;
 import opennlp.tools.formats.ad.ADSentenceStream.SentenceParser.Node;
 import opennlp.tools.util.FilterObjectStream;
@@ -89,6 +92,7 @@ public class ADSentenceStream extends FilterObjectStream<String, ADSentenceStrea
    */
   public static class SentenceParser {
 
+    private static final Logger logger = LoggerFactory.getLogger(SentenceParser.class);
     private static final Pattern NODE_PATTERN = Pattern
         .compile("([=-]*)([^:=]+:[^\\(\\s]+)(\\(([^\\)]+)\\))?\\s*(?:(\\((<.+>)\\))*)\\s*$");
     private static final Pattern LEAF_PATTERN = Pattern
@@ -219,7 +223,7 @@ public class ADSentenceStream extends FilterObjectStream<String, ADSentenceStrea
               if (!nodeStack.isEmpty() && nodeStack.peek().getLevel() < element.getLevel()) {
                 nodeStack.peek().addElement(element);
               } else {
-                System.err.println("should not happen!");
+                logger.warn("should not happen!");
               }
               // 4) Add it to the stack so it is a parent candidate.
               nodeStack.push((Node) element);
@@ -230,8 +234,7 @@ public class ADSentenceStream extends FilterObjectStream<String, ADSentenceStrea
         }
 
       } catch (Exception e) {
-        System.err.println(sentenceString);
-        e.printStackTrace();
+        logger.warn("Caught exception for the given sentence: '{}'", sentenceString, e);
         return sentence;
       }
       // second line should be SOURCE
@@ -341,7 +344,7 @@ public class ADSentenceStream extends FilterObjectStream<String, ADSentenceStrea
         }
       }
 
-      System.err.println("Couldn't parse leaf: " + line);
+      logger.warn("Couldn't parse leaf: {}", line);
       Leaf leaf = new Leaf();
       leaf.setLevel(1);
       leaf.setSyntacticTag("");

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/brat/BratDocumentParser.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/brat/BratDocumentParser.java
@@ -26,12 +26,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.namefind.NameSample;
 import opennlp.tools.sentdetect.SentenceDetector;
 import opennlp.tools.tokenize.Tokenizer;
 import opennlp.tools.util.Span;
 
 public class BratDocumentParser {
+
+  private static final Logger logger = LoggerFactory.getLogger(BratDocumentParser.class);
 
   private final SentenceDetector sentDetector;
   private final Tokenizer tokenizer;
@@ -86,8 +91,7 @@ public class BratDocumentParser {
         Span lastSentence = sentences.remove(sentences.size() - 1);
         sentences.add(new Span(lastSentence.getStart(), sentence.getEnd()));
 
-        System.out.println("Correcting sentence segmentation in document " +
-            sample.getId());
+        logger.info("Correcting sentence segmentation in document {}", sample.getId());
       }
       else {
         sentences.add(sentence);
@@ -144,7 +148,7 @@ public class BratDocumentParser {
               if (nameBeginIndex != null && nameEndIndex != null) {
                 mappedFragments.add(new Span(nameBeginIndex, nameEndIndex, entity.getType()));
               } else {
-                System.err.println("Dropped entity " + entity.getId() + " ("
+                logger.warn("Dropped entity " + entity.getId() + " ("
                     + entitySpan.getCoveredText(sample.getText()) + ") " + " in document "
                     + sample.getId() + ", it is not matching tokenization!");
               }
@@ -175,8 +179,8 @@ public class BratDocumentParser {
     }
 
     for (String id : entityIdSet) {
-      System.err.println("Dropped entity " + id + " in document " +
-          sample.getId() + ", is not matching sentence segmentation!");
+      logger.warn("Dropped entity {} in document {}"
+              + ", is not matching sentence segmentation!", id, sample.getId());
     }
 
     return samples;

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocument.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocument.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import javax.xml.parsers.SAXParser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import opennlp.tools.util.Span;
@@ -41,6 +43,7 @@ import opennlp.tools.util.XmlUtil;
 
 public class MascDocument {
 
+  private static final Logger logger = LoggerFactory.getLogger(MascDocument.class);
   private final List<MascSentence> sentences;
   private final String pathToFile;
   private Iterator<MascSentence> sentenceIterator;
@@ -222,8 +225,7 @@ public class MascDocument {
       try {
         saxParser.parse(bStream, handler);
       } catch (SAXException e) {
-        System.out.println(e.getMessage());
-        throw new IOException("Could not parse the named entity annotation file");
+        throw new IOException("Could not parse the named entity annotation file", e);
       }
 
       Map<Integer, String> entityIDtoEntityType = handler.getEntityIDtoEntityType();
@@ -323,15 +325,13 @@ public class MascDocument {
       for (MascSentence s : sentences) {
         boolean success = s.addNamedEntities(entityIDtoEntityType, entityIDsToTokens);
         if (!success) {
-          System.out.println("\tIssues occurred in the file: " + pathToFile);
+          logger.warn("Issues occurred in the file:  {}", pathToFile);
         }
       }
       hasNamedEntities = true;
     } catch (IOException e) {
-      System.err.println("[ERROR] Failed connecting tokens and named entities.");
-      System.err.println("\tThe error occurred in the file: " + pathToFile);
-      System.err.println(e.getMessage());
-      System.err.println(Arrays.toString(e.getStackTrace()));
+      logger.error("Failed connecting tokens and named entities. " +
+              "The error occurred in the file: {}", pathToFile, e);
     }
   }
 
@@ -353,7 +353,7 @@ public class MascDocument {
       //Check that all tokens have at least one quark.
       for (Map.Entry<Integer, int[]> token : tokenToQuarks.entrySet()) {
         if (token.getValue().length == 0) {
-          System.err.println("[ERROR] Token without quarks: " + token.getKey());
+          logger.error("Token without quarks: {}", token.getKey());
         }
       }
 
@@ -369,9 +369,8 @@ public class MascDocument {
             int[] newTokens = new int[tokens.length + 1];
             newTokens[0] = token;
             System.arraycopy(tokens, 0, newTokens, 1, tokens.length);
-            System.out.println("[WARNING] One quark belongs to several tokens. f-seg ID: " +
-                quark);
-            System.out.println("\tThe error occurred in file: " + pathToFile);
+            logger.warn("One quark belongs to several tokens. f-seg ID: {}.", quark);
+            logger.warn("The error occurred in file: {}", pathToFile);
             quarkToTokens.put(quark, newTokens);
           } else {
             quarkToTokens.put(quark, new int[] {token});
@@ -382,7 +381,7 @@ public class MascDocument {
       for (MascSentence s : sentences) {
         boolean success = s.tokenizePenn(tokenToQuarks, quarkToTokens, tokenToBase, tokenToTag);
         if (!success) {
-          System.out.println("\tIssue occurred in file: " + pathToFile);
+          logger.warn("Issues occurred in the file:  {}", pathToFile);
         }
       }
 

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocumentStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascDocumentStream.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Stack;
 import javax.xml.parsers.SAXParser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -40,6 +42,7 @@ import opennlp.tools.util.XmlUtil;
 
 public class MascDocumentStream implements ObjectStream<MascDocument> {
 
+  private static final Logger logger = LoggerFactory.getLogger(MascDocumentStream.class);
   /**
    * A helper class to parse the header (.hdr) files.
    */
@@ -140,8 +143,7 @@ public class MascDocumentStream implements ObjectStream<MascDocument> {
               documents.add(MascDocument.parseDocument(hdrFilePath, f_primary, f_seg,
                   f_penn, f_s, f_ne));
             } catch (IOException e) {
-              System.err.println("Failed to parse the file: " + hdrFilePath);
-              System.err.println('\t' + e.getMessage());
+              logger.warn("Failed to parse the file: {}", hdrFilePath, e);
               failedLoads++;
             }
           }
@@ -152,9 +154,9 @@ public class MascDocumentStream implements ObjectStream<MascDocument> {
       }
     }
 
-    System.out.println("Documents loaded: " + documents.size());
+    logger.info("Documents loaded: {}", documents.size());
     if (failedLoads > 0) {
-      System.err.println("Failed loading " + failedLoads + " documents.");
+      logger.info("Failed loading {} documents.", failedLoads);
     }
     reset();
 

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascNamedEntityParser.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascNamedEntityParser.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -30,6 +32,8 @@ import org.xml.sax.helpers.DefaultHandler;
  * A class to process the MASC Named entity stand-off annotation file
  */
 public class MascNamedEntityParser extends DefaultHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(MascNamedEntityParser.class);
 
   private final Map<Integer, String> entityIDtoEntityType = new HashMap<>();
   private final Map<Integer, List<Integer>> entityIDsToTokens = new HashMap<>();
@@ -83,7 +87,7 @@ public class MascNamedEntityParser extends DefaultHandler {
         //todo: Do we want to give the user control over which types have priority?
         String type = entityIDtoEntityType.get(entityID);
         if (tokenToEntity.containsKey(tokenID) && !type.equals(tokenToEntity.get(tokenID))) {
-          System.out.println("[WARNING] One token assigned to different named entity types.\n" +
+          logger.warn("One token assigned to different named entity types.\n" +
               "\tPenn-TokenID: " + tokenID + "\n\tToken types: \"" + type + "\", \"" +
               tokenToEntity.get(tokenID) + "\"\n\tKeeping only " + "\"type\"");
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascSentence.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascSentence.java
@@ -27,11 +27,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.Span;
 
 public class MascSentence extends Span {
 
-  private static final long serialVersionUID = -3963079332759345419L;
+  private static final Logger logger = LoggerFactory.getLogger(MascSentence.class);
+  private static final long serialVersionUID = 6295507533472650848L;
 
   private static class QuarkExtractor {
 
@@ -141,15 +145,15 @@ public class MascSentence extends Span {
 
             int[] quarksOfToken = tokenToQuarks.get(token); // Get the quark IDs contained in the token
             if (quarksOfToken == null) {
-              System.err.println("Token without quarks found: " + token);
+              logger.warn("Token without quarks found: {}", token);
             }
 
             for (int quark : quarksOfToken) {
               if (!wordsById.containsKey(quark)) {
                 fileWithoutIssues = false;
-                System.out.println("[WARNING] Some tokens cross sentence boundaries." +
-                    "\n\tQuark ID: " + quark +
-                    "\n\tPenn token ID: " + token);
+                logger.warn("Some tokens cross sentence boundaries." +
+                    "\n\tQuark ID: {}" +
+                    "\n\tPenn token ID: {}", quark, token );
               }
             }
 
@@ -239,7 +243,7 @@ public class MascSentence extends Span {
       Span leftSpan = namedEntities.get(leftIndex);
       Span rightSpan = namedEntities.get(rightIndex);
       if (leftSpan.contains(rightSpan) || leftSpan.crosses(rightSpan)) {
-        System.out.println("[WARNING] Named entities overlap. This is forbidden in the OpenNLP." +
+        logger.warn("Named entities overlap. This is forbidden in the OpenNLP." +
             "\n\tKeeping the longer of them.");
         if (rightSpan.length() > leftSpan.length()) {
           overlaps.add(leftIndex);

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascTokenSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/masc/MascTokenSampleStream.java
@@ -20,6 +20,9 @@ package opennlp.tools.formats.masc;
 import java.io.IOException;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.tokenize.TokenSample;
 import opennlp.tools.util.FilterObjectStream;
 import opennlp.tools.util.ObjectStream;
@@ -27,6 +30,7 @@ import opennlp.tools.util.Span;
 
 public class MascTokenSampleStream extends FilterObjectStream<MascDocument, TokenSample> {
 
+  private static final Logger logger = LoggerFactory.getLogger(MascTokenSampleStream.class);
   private MascDocument buffer;
 
   /**
@@ -76,20 +80,16 @@ public class MascTokenSampleStream extends FilterObjectStream<MascDocument, Toke
         tokenSpans = sentence.getTokensSpans();
 
         if (sentenceString.length() == 0) {
-          System.err.println("[WARNING] Zero sentence found: " +
-              "there is a sentence without any tokens.");
-          System.err.println(sentenceString);
-          System.err.println(tokenSpans.toString());
+          logger.warn("Zero sentence found. There is a sentence " +
+                  "without any tokens. sentence: {}, spans: {}", sentenceString, tokenSpans);
           sentenceFound = false;
         }
 
         for (int i = 0; i < tokenSpans.size(); i++) {
           Span t = tokenSpans.get(i);
           if (t.getEnd() - t.getStart() == 0) {
-            System.err.println("[WARNING] Zero token found: " +
-                "there is a token without any quarks.");
-            System.err.println(sentenceString);
-            System.err.println(tokenSpans);
+            logger.warn("Zero token found. There is a token without any quarks." +
+                    " sentence: {}, spans: {}", sentenceString, tokenSpans);
             sentenceFound = false;
           }
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/lemmatizer/LemmaSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/lemmatizer/LemmaSampleStream.java
@@ -21,9 +21,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.FilterObjectStream;
 import opennlp.tools.util.ObjectStream;
-
 
 /**
  * Reads data for training and testing the {@link Lemmatizer}.
@@ -32,6 +34,8 @@ import opennlp.tools.util.ObjectStream;
  * {@code word\tpostag\tlemma}.
  */
 public class LemmaSampleStream extends FilterObjectStream<String, LemmaSample> {
+
+  private static final Logger logger = LoggerFactory.getLogger(LemmaSampleStream.class);
 
   /**
    * Initializes a {@link LemmaSampleStream instance}.
@@ -52,7 +56,7 @@ public class LemmaSampleStream extends FilterObjectStream<String, LemmaSample> {
     for (String line = samples.read(); line != null && !line.equals(""); line = samples.read()) {
       String[] parts = line.split("\t");
       if (parts.length != 3) {
-        System.err.println("Skipping corrupt line: " + line);
+        logger.warn("Skipping corrupt line: {}", line);
       }
       else {
         toks.add(parts[0]);

--- a/opennlp-tools/src/main/java/opennlp/tools/log/LogPrintStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/log/LogPrintStream.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package opennlp.tools.log;
+
+import java.io.PrintStream;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import opennlp.tools.commons.Internal;
+
+/**
+ * This class serves as an adapter for a {@link Logger} used within a {@link PrintStream}.
+ */
+@Internal
+public class LogPrintStream extends PrintStream {
+
+  private final Logger logger;
+  private final Level level;
+
+  /**
+   * Creates a {@link LogPrintStream} for the given {@link Logger}.
+   *
+   * @param logger must not be {@code null}
+   */
+  public LogPrintStream(Logger logger) {
+    this(logger, Level.INFO);
+  }
+
+  /**
+   * Creates a {@link LogPrintStream} for the given {@link Logger}, which logs at the specified
+   * {@link Level level}.
+   *
+   * @param logger must not be {@code null}
+   * @param level  must not be {@code null}
+   */
+  public LogPrintStream(Logger logger, Level level) {
+    super(nullOutputStream());
+    Objects.requireNonNull(logger, "logger must not be NULL.");
+    Objects.requireNonNull(level, "log level must not be NULL.");
+    this.logger = logger;
+    this.level = level;
+  }
+
+  @Override
+  public PrintStream printf(String format, Object... args) {
+    log(String.format(format, args));
+    return this;
+  }
+
+  @Override
+  public void println(String msg) {
+    log(msg);
+  }
+
+  private void log(String msg) {
+    switch (level) {
+      case TRACE:
+        logger.trace(msg);
+        break;
+      case DEBUG:
+        logger.debug(msg);
+        break;
+      case INFO:
+        logger.info(msg);
+        break;
+      case WARN:
+        logger.warn(msg);
+        break;
+      case ERROR:
+        logger.error(msg);
+        break;
+    }
+  }
+}

--- a/opennlp-tools/src/main/java/opennlp/tools/log/package-info.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/log/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package contains a {@link java.io.PrintStream} adapter for internal use only.
+ */
+package opennlp.tools.log;

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/AbstractTrainer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/AbstractTrainer.java
@@ -36,13 +36,8 @@ public abstract class AbstractTrainer implements Trainer {
   public static final String ITERATIONS_PARAM = "Iterations";
   public static final int ITERATIONS_DEFAULT = 100;
 
-  public static final String VERBOSE_PARAM = "PrintMessages";
-  public static final boolean VERBOSE_DEFAULT = true;
-
   protected TrainingParameters trainingParameters;
   protected Map<String,String> reportMap;
-
-  protected boolean printMessages;
 
   public AbstractTrainer() {
   }
@@ -68,7 +63,6 @@ public abstract class AbstractTrainer implements Trainer {
     this.trainingParameters = trainParams;
     if (reportMap == null) reportMap = new HashMap<>();
     this.reportMap = reportMap;
-    printMessages = trainParams.getBooleanParameter(VERBOSE_PARAM, VERBOSE_DEFAULT);
   }
 
   /**
@@ -201,9 +195,4 @@ public abstract class AbstractTrainer implements Trainer {
     reportMap.put(key, value);
   }
 
-  protected void display(String s) {
-    if (printMessages) {
-      System.out.print(s);
-    }
-  }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/GISModelReader.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/GISModelReader.java
@@ -20,6 +20,9 @@ package opennlp.tools.ml.maxent.io;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.maxent.GISModel;
 import opennlp.tools.ml.model.AbstractModel;
 import opennlp.tools.ml.model.AbstractModelReader;
@@ -47,6 +50,8 @@ import opennlp.tools.ml.model.DataReader;
  * @see AbstractModelReader
  */
 public class GISModelReader extends AbstractModelReader {
+
+  private static final Logger logger = LoggerFactory.getLogger(GISModelReader.class);
 
   /**
    * Initializes a {@link GISModelReader} via a {@link File}.
@@ -99,7 +104,7 @@ public class GISModelReader extends AbstractModelReader {
   public void checkModelType() throws java.io.IOException {
     String modelType = readUTF();
     if (!modelType.equals("GIS"))
-      System.out.println("Error: attempting to load a " + modelType
-          + " model as a GIS model." + " You should expect problems.");
+      logger.error("Attempting to load a {}"
+          + " model as a GIS model. You should expect problems.", modelType);
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/QNModelReader.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/io/QNModelReader.java
@@ -20,6 +20,9 @@ package opennlp.tools.ml.maxent.io;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.maxent.quasinewton.QNModel;
 import opennlp.tools.ml.model.Context;
 import opennlp.tools.ml.model.DataReader;
@@ -31,6 +34,8 @@ import opennlp.tools.ml.model.DataReader;
  * @see GISModelReader
  */
 public class QNModelReader extends GISModelReader {
+
+  private static final Logger logger = LoggerFactory.getLogger(QNModelReader.class);
 
   /**
    * Initializes a {@link QNModelReader} via a {@link DataReader}.
@@ -56,8 +61,8 @@ public class QNModelReader extends GISModelReader {
   public void checkModelType() throws IOException {
     String modelType = readUTF();
     if (!modelType.equals("QN"))
-      System.out.println("Error: attempting to load a " + modelType
-          + " model as a MAXENT_QN model." + " You should expect problems.");
+      logger.error("Attempting to load a {}"
+              + " model as a MAXENT_QN model. You should expect problems.", modelType);
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/quasinewton/ParallelNegLogLikelihood.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/maxent/quasinewton/ParallelNegLogLikelihood.java
@@ -26,6 +26,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.ArrayMath;
 import opennlp.tools.ml.model.DataIndexer;
 
@@ -33,6 +36,8 @@ import opennlp.tools.ml.model.DataIndexer;
  * Evaluate negative log-likelihood and its gradient in parallel
  */
 public class ParallelNegLogLikelihood extends NegLogLikelihood {
+
+  private static final Logger logger = LoggerFactory.getLogger(ParallelNegLogLikelihood.class);
 
   // Number of threads
   private final int threads;
@@ -149,7 +154,7 @@ public class ParallelNegLogLikelihood extends NegLogLikelihood {
         future.get();
 
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.warn(e.getLocalizedMessage(), e);
     }
 
     executor.shutdown();

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/AbstractDataIndexer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/AbstractDataIndexer.java
@@ -27,11 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.AbstractTrainer;
 import opennlp.tools.util.InsufficientTrainingDataException;
 import opennlp.tools.util.ObjectStream;
 import opennlp.tools.util.TrainingParameters;
-
 
 /**
  * Abstract {@link DataIndexer} implementation for collecting
@@ -40,6 +42,8 @@ import opennlp.tools.util.TrainingParameters;
  * @see DataIndexer
  */
 public abstract class AbstractDataIndexer implements DataIndexer {
+
+  private static final Logger logger = LoggerFactory.getLogger(AbstractDataIndexer.class);
 
   public static final String CUTOFF_PARAM = AbstractTrainer.CUTOFF_PARAM;
   public static final int CUTOFF_DEFAULT = AbstractTrainer.CUTOFF_DEFAULT;
@@ -50,8 +54,6 @@ public abstract class AbstractDataIndexer implements DataIndexer {
   protected TrainingParameters trainingParameters;
   protected Map<String,String> reportMap;
 
-  protected boolean printMessages;
-
   /**
    * {@inheritDoc}
    */
@@ -60,9 +62,6 @@ public abstract class AbstractDataIndexer implements DataIndexer {
     this.reportMap = reportMap;
     if (this.reportMap == null) reportMap = new HashMap<>();
     trainingParameters = indexingParameters;
-
-    printMessages = trainingParameters.getBooleanParameter(AbstractTrainer.VERBOSE_PARAM,
-        AbstractTrainer.VERBOSE_DEFAULT);
   }
 
   private int numEvents;
@@ -179,7 +178,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
       throw new InsufficientTrainingDataException("Insufficient training data to create model.");
     }
 
-    if (sort) display("done. Reduced " + numEvents + " events to " + numUniqueEvents + ".\n");
+    if (sort) logger.info("done. Reduced {} events to {}.", numEvents, numUniqueEvents);
 
     contexts = new int[numUniqueEvents][];
     outcomeList = new int[numUniqueEvents];
@@ -230,8 +229,7 @@ public abstract class AbstractDataIndexer implements DataIndexer {
         int ocID = omap.get(ev.getOutcome());
         eventsToCompare.add(new ComparableEvent(ocID, cons, ev.getValues()));
       } else {
-        display("Dropped event " + ev.getOutcome() + ":"
-            + Arrays.asList(ev.getContext()) + "\n");
+        logger.info("Dropped event {}:{}", ev.getOutcome(), Arrays.asList(ev.getContext()));
       }
     }
     outcomeLabels = toIndexedStringArray(omap);
@@ -271,9 +269,4 @@ public abstract class AbstractDataIndexer implements DataIndexer {
     return null;
   }
 
-  protected void display(String s) {
-    if (printMessages) {
-      System.out.print(s);
-    }
-  }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/OnePassDataIndexer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/OnePassDataIndexer.java
@@ -23,6 +23,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.ObjectStream;
 import opennlp.tools.util.ObjectStreamUtils;
 
@@ -36,6 +39,8 @@ import opennlp.tools.util.ObjectStreamUtils;
  */
 public class OnePassDataIndexer extends AbstractDataIndexer {
 
+  private static final Logger logger = LoggerFactory.getLogger(OnePassDataIndexer.class);
+
   public OnePassDataIndexer() {}
 
   /**
@@ -48,22 +53,22 @@ public class OnePassDataIndexer extends AbstractDataIndexer {
 
     long start = System.currentTimeMillis();
 
-    display("Indexing events with OnePass using cutoff of " + cutoff + "\n\n");
+    logger.info("Indexing events with OnePass using cutoff of {}", cutoff);
 
-    display("\tComputing event counts...  ");
+    logger.info("Computing event counts...");
     Map<String, Integer> predicateIndex = new HashMap<>();
     List<Event> events = computeEventCounts(eventStream, predicateIndex, cutoff);
-    display("done. " + events.size() + " events\n");
+    logger.info("done. {} events", events.size());
 
-    display("\tIndexing...  ");
+    logger.info("Indexing...  ");
     List<ComparableEvent> eventsToCompare =
         index(ObjectStreamUtils.createObjectStream(events), predicateIndex);
 
-    display("done.\n");
+    logger.info("done.");
 
-    display("Sorting and merging events... ");
+    logger.info("Sorting and merging events... ");
     sortAndMerge(eventsToCompare, sort);
-    display(String.format("Done indexing in %.2f s.\n", (System.currentTimeMillis() - start) / 1000d));
+    logger.info(String.format("Done indexing in %.2f s.", (System.currentTimeMillis() - start) / 1000d));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/RealValueFileEventStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/RealValueFileEventStream.java
@@ -20,6 +20,9 @@ package opennlp.tools.ml.model;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.ObjectStream;
 
 /**
@@ -32,6 +35,8 @@ import opennlp.tools.util.ObjectStream;
  * @see FileEventStream
  */
 public class RealValueFileEventStream extends FileEventStream {
+
+  private static final Logger logger = LoggerFactory.getLogger(RealValueFileEventStream.class);
 
   /**
    * Instantiates a {@link RealValueFileEventStream} from the specified file name.
@@ -86,7 +91,7 @@ public class RealValueFileEventStream extends FileEventStream {
           values[ci] = Float.parseFloat(contexts[ci].substring(ei + 1));
         } catch (NumberFormatException e) {
           gotReal = false;
-          System.err.println("Unable to determine value in context:" + contexts[ci]);
+          logger.error("Unable to determine value in context: {}", contexts[ci]);
           values[ci] = 1;
         }
         if (gotReal) {

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/model/TwoPassDataIndexer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/model/TwoPassDataIndexer.java
@@ -32,8 +32,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import opennlp.tools.util.ObjectStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import opennlp.tools.util.ObjectStream;
 
 /**
  * Collecting event and context counts by making two passes over the events.
@@ -49,6 +51,8 @@ import opennlp.tools.util.ObjectStream;
  */
 public class TwoPassDataIndexer extends AbstractDataIndexer {
 
+  private static final Logger logger = LoggerFactory.getLogger(TwoPassDataIndexer.class);
+
   public TwoPassDataIndexer() {}
 
   /**
@@ -61,9 +65,9 @@ public class TwoPassDataIndexer extends AbstractDataIndexer {
 
     long start = System.currentTimeMillis();
 
-    display("Indexing events with TwoPass using cutoff of " + cutoff + "\n\n");
+    logger.info("Indexing events with TwoPass using cutoff of {}", cutoff);
 
-    display("\tComputing event counts...  ");
+    logger.info("Computing event counts...");
 
     Map<String,Integer> predicateIndex = new HashMap<>();
 
@@ -77,9 +81,8 @@ public class TwoPassDataIndexer extends AbstractDataIndexer {
     }
     writeHash = writeEventStream.calculateHashSum();
 
-    display("done. " + numEvents + " events\n");
-
-    display("\tIndexing...  ");
+    logger.info("done. {} events", numEvents);
+    logger.info("Indexing...");
 
     List<ComparableEvent> eventsToCompare;
     BigInteger readHash = null;
@@ -92,16 +95,16 @@ public class TwoPassDataIndexer extends AbstractDataIndexer {
     if (readHash.compareTo(writeHash) != 0)
       throw new IOException("Event hash for writing and reading events did not match.");
 
-    display("done.\n");
+    logger.info("done.");
 
     if (sort) {
-      display("Sorting and merging events... ");
+      logger.info("Sorting and merging events... ");
     }
     else {
-      display("Collecting events... ");
+      logger.info("Collecting events... ");
     }
     sortAndMerge(eventsToCompare,sort);
-    display(String.format("Done indexing in %.2f s.\n", (System.currentTimeMillis() - start) / 1000d));
+    logger.info(String.format("Done indexing in %.2f s.", (System.currentTimeMillis() - start) / 1000d));
   }
 
   /**

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/naivebayes/NaiveBayesModelReader.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/naivebayes/NaiveBayesModelReader.java
@@ -20,6 +20,9 @@ package opennlp.tools.ml.naivebayes;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.model.AbstractModel;
 import opennlp.tools.ml.model.AbstractModelReader;
 import opennlp.tools.ml.model.Context;
@@ -44,6 +47,7 @@ import opennlp.tools.ml.model.DataReader;
  */
 public class NaiveBayesModelReader extends AbstractModelReader {
 
+  private static final Logger logger = LoggerFactory.getLogger(NaiveBayesModelReader.class);
   /**
    * Initializes a {@link NaiveBayesModelReader} via a {@link File}.
    *
@@ -94,8 +98,8 @@ public class NaiveBayesModelReader extends AbstractModelReader {
   public void checkModelType() throws IOException {
     String modelType = readUTF();
     if (!modelType.equals("NaiveBayes"))
-      System.out.println("Error: attempting to load a " + modelType +
+      logger.error("Attempting to load a {}" +
           " model as a NaiveBayes model." +
-          " You should expect problems.");
+          " You should expect problems.", modelType);
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/naivebayes/NaiveBayesModelWriter.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/naivebayes/NaiveBayesModelWriter.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.tools.ml.model.AbstractModel;
 import opennlp.tools.ml.model.AbstractModelWriter;
@@ -40,6 +42,9 @@ import opennlp.tools.ml.model.Context;
  * @see AbstractModelWriter
  */
 public abstract class NaiveBayesModelWriter extends AbstractModelWriter {
+
+  private static final Logger logger = LoggerFactory.getLogger(NaiveBayesModelWriter.class);
+
   protected Context[] PARAMS;
   protected String[] OUTCOME_LABELS;
   protected String[] PRED_LABELS;
@@ -145,7 +150,7 @@ public abstract class NaiveBayesModelWriter extends AbstractModelWriter {
       }
     }
     outcomePatterns.add(newGroup);
-    System.err.println(outcomePatterns.size() + " outcome patterns");
+    logger.info("{} outcome patterns", outcomePatterns.size());
     return outcomePatterns;
   }
   

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/naivebayes/NaiveBayesTrainer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/naivebayes/NaiveBayesTrainer.java
@@ -19,6 +19,9 @@ package opennlp.tools.ml.naivebayes;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.AbstractEventTrainer;
 import opennlp.tools.ml.ArrayMath;
 import opennlp.tools.ml.model.AbstractModel;
@@ -39,6 +42,8 @@ import opennlp.tools.util.TrainingParameters;
  * @see AbstractEventTrainer
  */
 public class NaiveBayesTrainer extends AbstractEventTrainer {
+
+  private static final Logger logger = LoggerFactory.getLogger(NaiveBayesTrainer.class);
 
   public static final String NAIVE_BAYES_VALUE = "NAIVEBAYES";
 
@@ -131,7 +136,7 @@ public class NaiveBayesTrainer extends AbstractEventTrainer {
    * @return A valid, trained {@link AbstractModel Naive Bayes model}.
    */
   public AbstractModel trainModel(DataIndexer di) {
-    display("Incorporating indexed data for training...  \n");
+    logger.info("Incorporating indexed data for training...");
     contexts = di.getContexts();
     values = di.getValues();
     numTimesEventsSeen = di.getNumTimesEventsSeen();
@@ -145,17 +150,17 @@ public class NaiveBayesTrainer extends AbstractEventTrainer {
     numPreds = predLabels.length;
     numOutcomes = outcomeLabels.length;
 
-    display("done.\n");
+    logger.info("done.");
 
-    display("\tNumber of Event Tokens: " + numUniqueEvents + "\n");
-    display("\t    Number of Outcomes: " + numOutcomes + "\n");
-    display("\t  Number of Predicates: " + numPreds + "\n");
+    logger.info("\tNumber of Event Tokens: {} " +
+        "\n\t Number of Outcomes: {} " +
+        "\n\t Number of Predicates: {}", numUniqueEvents, numOutcomes, numPreds);
 
-    display("Computing model parameters...\n");
+    logger.info("Computing model parameters...");
 
     MutableContext[] finalParameters = findParameters();
 
-    display("...done.\n");
+    logger.info("...done.");
 
     /* Create and return the model ****/
     return new NaiveBayesModel(finalParameters, predLabels, outcomeLabels);
@@ -228,7 +233,7 @@ public class NaiveBayesTrainer extends AbstractEventTrainer {
       }
     }
     double trainingAccuracy = (double) numCorrect / numEvents;
-    display("Stats: (" + numCorrect + "/" + numEvents + ") " + trainingAccuracy + "\n");
+    logger.info("Stats: (" + numCorrect + "/" + numEvents + ") " + trainingAccuracy);
     return trainingAccuracy;
   }
 

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/perceptron/PerceptronModelReader.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/perceptron/PerceptronModelReader.java
@@ -20,6 +20,9 @@ package opennlp.tools.ml.perceptron;
 import java.io.File;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.model.AbstractModel;
 import opennlp.tools.ml.model.AbstractModelReader;
 import opennlp.tools.ml.model.Context;
@@ -43,6 +46,8 @@ import opennlp.tools.ml.model.DataReader;
  * @see AbstractModelReader
  */
 public class PerceptronModelReader extends AbstractModelReader {
+
+  private static final Logger logger = LoggerFactory.getLogger(PerceptronModelReader.class);
 
   /**
    * Initializes a {@link PerceptronModelReader} via a {@link File}.
@@ -94,7 +99,8 @@ public class PerceptronModelReader extends AbstractModelReader {
   public void checkModelType() throws IOException {
     String modelType = readUTF();
     if (!modelType.equals("Perceptron"))
-      System.out.println("Error: attempting to load a " + modelType +
-          " model as a Perceptron model. You should expect problems.");
+      logger.error("Attempting to load a {} " +
+              " model as a Perceptron model." +
+              " You should expect problems.", modelType);
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/perceptron/PerceptronModelWriter.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/perceptron/PerceptronModelWriter.java
@@ -23,6 +23,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.model.AbstractModel;
 import opennlp.tools.ml.model.AbstractModelWriter;
 import opennlp.tools.ml.model.ComparablePredicate;
@@ -39,6 +42,8 @@ import opennlp.tools.ml.model.Context;
  * @see AbstractModelWriter
  */
 public abstract class PerceptronModelWriter extends AbstractModelWriter {
+
+  private static final Logger logger = LoggerFactory.getLogger(PerceptronModelWriter.class);
   protected Context[] PARAMS;
   protected String[] OUTCOME_LABELS;
   protected String[] PRED_LABELS;
@@ -108,7 +113,7 @@ public abstract class PerceptronModelWriter extends AbstractModelWriter {
         numPreds++;
       }
     }
-    System.out.println("Compressed " + PARAMS.length + " parameters to " + numPreds);
+    logger.info("Compressed {} parameters to {}", PARAMS.length , numPreds);
     sortPreds = new ComparablePredicate[numPreds];
     System.arraycopy(tmpPreds, 0, sortPreds, 0, numPreds);
     Arrays.sort(sortPreds);
@@ -136,7 +141,7 @@ public abstract class PerceptronModelWriter extends AbstractModelWriter {
       }
     }
     outcomePatterns.add(newGroup);
-    System.out.println(outcomePatterns.size() + " outcome patterns");
+    logger.info("{} outcome patterns", outcomePatterns.size());
     return outcomePatterns;
   }
 

--- a/opennlp-tools/src/main/java/opennlp/tools/parser/Parse.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/parser/Parse.java
@@ -30,6 +30,9 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.Span;
 
 /**
@@ -37,6 +40,7 @@ import opennlp.tools.util.Span;
  */
 public class Parse implements Cloneable, Comparable<Parse> {
 
+  private static final Logger logger = LoggerFactory.getLogger(Parse.class);
   public static final String BRACKET_LRB = "(";
   public static final String BRACKET_RRB = ")";
   public static final String BRACKET_LCB = "{";
@@ -139,10 +143,10 @@ public class Parse implements Cloneable, Comparable<Parse> {
    * Initializes a {@link Parse node} for this specified {@code text} and {@code span} of the
    * specified {@code type} with probability {@code p} and the head {@code index}.
    *
-   * @param text The text of the sentence for which this node is a part of.
-   * @param span The {@link Span character offsets} for this node within the specified {@code text}.
-   * @param type The constituent label of this node.
-   * @param p The probability of this {@link Parse}.
+   * @param text  The text of the sentence for which this node is a part of.
+   * @param span  The {@link Span character offsets} for this node within the specified {@code text}.
+   * @param type  The constituent label of this node.
+   * @param p     The probability of this {@link Parse}.
    * @param index The token index of the head of this parse.
    */
   public Parse(String text, Span span, String type, double p, int index) {
@@ -164,8 +168,8 @@ public class Parse implements Cloneable, Comparable<Parse> {
    * @param text The text of the sentence for which this node is a part of.
    * @param span The {@link Span character offsets} for this node within the specified {@code text}.
    * @param type The constituent label of this node.
-   * @param p The probability of this parse.
-   * @param h The head token of this parse.
+   * @param p    The probability of this parse.
+   * @param h    The head token of this parse.
    */
   public Parse(String text, Span span, String type, double p, Parse h) {
     this(text, span, type, p, 0);
@@ -198,11 +202,10 @@ public class Parse implements Cloneable, Comparable<Parse> {
   public Parse clone(Parse node) {
     if (this == node) {
       return (Parse) this.clone();
-    }
-    else {
+    } else {
       Parse c = (Parse) this.clone();
       Parse lc = c.parts.get(parts.size() - 1);
-      c.parts.set(parts.size() - 1,lc.clone(node));
+      c.parts.set(parts.size() - 1, lc.clone(node));
       return c;
     }
   }
@@ -210,14 +213,14 @@ public class Parse implements Cloneable, Comparable<Parse> {
   /**
    * Clones the right frontier of this root {@link Parse} up to and including the specified node.
    *
-   * @param node The last {@code node} in the right frontier of the parse tree to be cloned.
+   * @param node       The last {@code node} in the right frontier of the parse tree to be cloned.
    * @param parseIndex The child index of the parse for this root {@code node}.
    * @return A clone of this root parse and its right frontier up to and including the specified node.
    */
   public Parse cloneRoot(Parse node, int parseIndex) {
     Parse c = (Parse) this.clone();
     Parse fc = c.parts.get(parseIndex);
-    c.parts.set(parseIndex,fc.clone(node));
+    c.parts.set(parseIndex, fc.clone(node));
     return c;
   }
 
@@ -249,7 +252,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
 
   /**
    * @return Retrieves the set of punctuation {@link Parse parses} that occur
-   *         immediately before this parse.
+   * immediately before this parse.
    */
   public Collection<Parse> getPreviousPunctuationSet() {
     return prevPunctSet;
@@ -269,7 +272,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
 
   /**
    * @return Retrieves the set of punctuation {@link Parse parses} that occur
-   *         immediately after this parse.
+   * immediately after this parse.
    */
   public Collection<Parse> getNextPunctuationSet() {
     return nextPunctSet;
@@ -319,34 +322,43 @@ public class Parse implements Cloneable, Comparable<Parse> {
       int pn = parts.size();
       for (; pi < pn; pi++) {
         Parse subPart = parts.get(pi);
-        //System.err.println("Parse.insert:con="+constituent+" sp["+pi+"] "+subPart+" "+subPart.getType());
+        if (logger.isTraceEnabled()) {
+          logger.trace("Parse.insert:con=" + constituent + " sp[" + pi + "] "
+              + subPart + " " + subPart.getType());
+        }
         Span sp = subPart.span;
         if (sp.getStart() >= ic.getEnd()) {
           break;
         }
         // constituent contains subPart
         else if (ic.contains(sp)) {
-          //System.err.println("Parse.insert:con contains subPart");
+          if (logger.isTraceEnabled()) {
+            logger.trace("Parse.insert:con contains subPart");
+          }
           parts.remove(pi);
           pi--;
           constituent.parts.add(subPart);
           subPart.setParent(constituent);
-          //System.err.println("Parse.insert: "+subPart.hashCode()+" -> "+subPart.getParent().hashCode());
+          if (logger.isTraceEnabled()) {
+            logger.trace("Parse.insert: " + subPart.hashCode() + " -> " + subPart.getParent().hashCode());
+          }
           pn = parts.size();
-        }
-        else if (sp.contains(ic)) {
-          //System.err.println("Parse.insert:subPart contains con");
+        } else if (sp.contains(ic)) {
+          if (logger.isTraceEnabled()) {
+            logger.trace("Parse.insert:subPart contains con");
+          }
           subPart.insert(constituent);
           return;
         }
       }
-      //System.err.println("Parse.insert:adding con="+constituent+" to "+this);
+      if (logger.isTraceEnabled()) {
+        logger.trace("Parse.insert:adding con=" + constituent + " to " + this);
+      }
       parts.add(pi, constituent);
       constituent.setParent(this);
       // System.err.println("Parse.insert: "+constituent.hashCode()+" -> "
       // +constituent.getParent().hashCode());
-    }
-    else {
+    } else {
       throw new IllegalArgumentException("Inserting constituent not contained in the sentence!");
     }
   }
@@ -362,14 +374,22 @@ public class Parse implements Cloneable, Comparable<Parse> {
     if (!type.equals(AbstractBottomUpParser.TOK_NODE)) {
       sb.append("(");
       sb.append(type).append(" ");
-      //System.out.print(label+" ");
-      //System.out.print(head+" ");
-      //System.out.print(df.format(prob)+" ");
+      if (logger.isTraceEnabled()) {
+        logger.trace(label + " ");
+      }
+      if (logger.isTraceEnabled()) {
+        logger.trace(head + " ");
+      }
+      if (logger.isTraceEnabled()) {
+        logger.trace(prob + " ");
+      }
     }
     for (Parse c : parts) {
       Span s = c.span;
       if (start < s.getStart()) {
-        //System.out.println("pre "+start+" "+s.getStart());
+        if (logger.isTraceEnabled()) {
+          logger.trace("pre " + start + " " + s.getStart());
+        }
         sb.append(encodeToken(text.substring(start, s.getStart())));
       }
       c.show(sb);
@@ -389,24 +409,26 @@ public class Parse implements Cloneable, Comparable<Parse> {
   public void show() {
     StringBuffer sb = new StringBuffer(text.length() * 4);
     show(sb);
-    System.out.println(sb);
+    logger.debug(sb.toString());
   }
 
   /**
    * @return Retrieves the probability associated with the pos-tag sequence assigned
-   *         to this parse.
+   * to this parse.
    */
   public double getTagSequenceProb() {
-    //System.err.println("Parse.getTagSequenceProb: "+type+" "+this);
+    if (logger.isTraceEnabled()) {
+      logger.trace("Parse.getTagSequenceProb: " + type + " " + this);
+    }
     if (parts.size() == 1 && (parts.get(0)).type.equals(AbstractBottomUpParser.TOK_NODE)) {
-      //System.err.println(this+" "+prob);
+      if (logger.isTraceEnabled()) {
+        logger.trace(this + " " + prob);
+      }
       return (StrictMath.log(prob));
-    }
-    else if (parts.size() == 0) {
-      System.err.println("Parse.getTagSequenceProb: Wrong base case!");
+    } else if (parts.size() == 0) {
+      logger.warn("Parse.getTagSequenceProb: Wrong base case!");
       return (0.0);
-    }
-    else {
+    } else {
       double sum = 0.0;
       for (Parse part : parts) {
         sum += part.getTagSequenceProb();
@@ -417,7 +439,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
 
   /**
    * @return {@code true} if the parse contains a single top-most node (=complete),
-   *         {@code false} otherwise.
+   * {@code false} otherwise.
    */
   public boolean complete() {
     return (parts.size() == 1);
@@ -488,7 +510,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
   public void setChild(int index, String label) {
     Parse newChild = (Parse) (parts.get(index)).clone();
     newChild.setLabel(label);
-    parts.set(index,newChild);
+    parts.set(index, newChild);
   }
 
   public void add(Parse daughter, HeadRules rules) {
@@ -496,31 +518,31 @@ public class Parse implements Cloneable, Comparable<Parse> {
       parts.addAll(daughter.prevPunctSet);
     }
     parts.add(daughter);
-    this.span = new Span(span.getStart(),daughter.getSpan().getEnd());
-    this.head = rules.getHead(getChildren(),type);
+    this.span = new Span(span.getStart(), daughter.getSpan().getEnd());
+    this.head = rules.getHead(getChildren(), type);
     this.headIndex = head.headIndex;
   }
 
   public void remove(int index) {
     parts.remove(index);
-    if (! parts.isEmpty()) {
+    if (!parts.isEmpty()) {
       if (index == 0 || index == parts.size()) { //size is orig last element
-        span = new Span((parts.get(0)).span.getStart(),(parts.get(parts.size() - 1)).span.getEnd());
+        span = new Span((parts.get(0)).span.getStart(), (parts.get(parts.size() - 1)).span.getEnd());
       }
     }
   }
 
   public Parse adjoinRoot(Parse node, HeadRules rules, int parseIndex) {
     Parse lastChild = parts.get(parseIndex);
-    Parse adjNode = new Parse(this.text,new Span(lastChild.getSpan().getStart(),
-        node.getSpan().getEnd()),lastChild.getType(),1,
-        rules.getHead(new Parse[]{lastChild,node},lastChild.getType()));
+    Parse adjNode = new Parse(this.text, new Span(lastChild.getSpan().getStart(),
+        node.getSpan().getEnd()), lastChild.getType(), 1,
+        rules.getHead(new Parse[] {lastChild, node}, lastChild.getType()));
     adjNode.parts.add(lastChild);
     if (node.prevPunctSet != null) {
       adjNode.parts.addAll(node.prevPunctSet);
     }
     adjNode.parts.add(node);
-    parts.set(parseIndex,adjNode);
+    parts.set(parseIndex, adjNode);
     return adjNode;
   }
 
@@ -529,39 +551,39 @@ public class Parse implements Cloneable, Comparable<Parse> {
    * new parent node. The new parent node replace this node's last child.
    *
    * @param sister The {@link Parse node} to be adjoined.
-   * @param rules The {@link HeadRules} for the parser.
+   * @param rules  The {@link HeadRules} for the parser.
    * @return The new {@link Parse parent node} of this node and the specified sister node.
    */
   public Parse adjoin(Parse sister, HeadRules rules) {
     Parse lastChild = parts.get(parts.size() - 1);
-    Parse adjNode = new Parse(this.text,new Span(lastChild.getSpan().getStart(),sister.getSpan().getEnd()),
-        lastChild.getType(),1,rules.getHead(new Parse[]{lastChild,sister},lastChild.getType()));
+    Parse adjNode = new Parse(this.text, new Span(lastChild.getSpan().getStart(), sister.getSpan().getEnd()),
+        lastChild.getType(), 1, rules.getHead(new Parse[] {lastChild, sister}, lastChild.getType()));
     adjNode.parts.add(lastChild);
     if (sister.prevPunctSet != null) {
       adjNode.parts.addAll(sister.prevPunctSet);
     }
     adjNode.parts.add(sister);
     parts.set(parts.size() - 1, adjNode);
-    this.span = new Span(span.getStart(),sister.getSpan().getEnd());
-    this.head = rules.getHead(getChildren(),type);
+    this.span = new Span(span.getStart(), sister.getSpan().getEnd());
+    this.head = rules.getHead(getChildren(), type);
     this.headIndex = head.headIndex;
     return adjNode;
   }
 
   public void expandTopNode(Parse root) {
     boolean beforeRoot = true;
-    //System.err.println("expandTopNode: parts="+parts);
-    for (int pi = 0, ai = 0; pi < parts.size(); pi++,ai++) {
+    if (logger.isTraceEnabled()) {
+      logger.trace("expandTopNode: parts=" + parts);
+    }
+    for (int pi = 0, ai = 0; pi < parts.size(); pi++, ai++) {
       Parse node = parts.get(pi);
       if (node == root) {
         beforeRoot = false;
-      }
-      else if (beforeRoot) {
-        root.parts.add(ai,node);
+      } else if (beforeRoot) {
+        root.parts.add(ai, node);
         parts.remove(pi);
         pi--;
-      }
-      else {
+      } else {
         root.parts.add(node);
         parts.remove(pi);
         pi--;
@@ -579,9 +601,8 @@ public class Parse implements Cloneable, Comparable<Parse> {
 
   /**
    * @param child A child of this parse.
-   *
    * @return Retrieves the index of this specified child or {@code -1}
-   *         if the specified child is not a child of this parse.
+   * if the specified child is not a child of this parse.
    */
   public int indexOf(Parse child) {
     return parts.indexOf(child);
@@ -624,27 +645,19 @@ public class Parse implements Cloneable, Comparable<Parse> {
   private static String getType(String rest) {
     if (rest.startsWith("-LCB-")) {
       return "-LCB-";
-    }
-    else if (rest.startsWith("-RCB-")) {
+    } else if (rest.startsWith("-RCB-")) {
       return "-RCB-";
-    }
-    else if (rest.startsWith("-LRB-")) {
+    } else if (rest.startsWith("-LRB-")) {
       return "-LRB-";
-    }
-    else if (rest.startsWith("-RRB-")) {
+    } else if (rest.startsWith("-RRB-")) {
       return "-RRB-";
-    }
-    else if (rest.startsWith("-RSB-")) {
+    } else if (rest.startsWith("-RSB-")) {
       return "-RSB-";
-    }
-    else if (rest.startsWith("-LSB-")) {
+    } else if (rest.startsWith("-LSB-")) {
       return "-LSB-";
-    }
-
-    else if (rest.startsWith("-NONE-")) {
+    } else if (rest.startsWith("-NONE-")) {
       return "-NONE-";
-    }
-    else {
+    } else {
       Matcher typeMatcher = typePattern.matcher(rest);
       if (typeMatcher.find()) {
         String type = typeMatcher.group(1);
@@ -664,20 +677,15 @@ public class Parse implements Cloneable, Comparable<Parse> {
   private static String encodeToken(String token) {
     if (BRACKET_LRB.equals(token)) {
       return "-LRB-";
-    }
-    else if (BRACKET_RRB.equals(token)) {
+    } else if (BRACKET_RRB.equals(token)) {
       return "-RRB-";
-    }
-    else if (BRACKET_LCB.equals(token)) {
+    } else if (BRACKET_LCB.equals(token)) {
       return "-LCB-";
-    }
-    else if (BRACKET_RCB.equals(token)) {
+    } else if (BRACKET_RCB.equals(token)) {
       return "-RCB-";
-    }
-    else if (BRACKET_LSB.equals(token)) {
+    } else if (BRACKET_LSB.equals(token)) {
       return "-LSB-";
-    }
-    else if (BRACKET_RSB.equals(token)) {
+    } else if (BRACKET_RSB.equals(token)) {
       return "-RSB-";
     }
 
@@ -687,20 +695,15 @@ public class Parse implements Cloneable, Comparable<Parse> {
   private static String decodeToken(String token) {
     if ("-LRB-".equals(token)) {
       return BRACKET_LRB;
-    }
-    else if ("-RRB-".equals(token)) {
+    } else if ("-RRB-".equals(token)) {
       return BRACKET_RRB;
-    }
-    else if ("-LCB-".equals(token)) {
+    } else if ("-LCB-".equals(token)) {
       return BRACKET_LCB;
-    }
-    else if ("-RCB-".equals(token)) {
+    } else if ("-RCB-".equals(token)) {
       return BRACKET_RCB;
-    }
-    else if ("-LSB-".equals(token)) {
+    } else if ("-LSB-".equals(token)) {
       return BRACKET_LSB;
-    }
-    else if ("-RSB-".equals(token)) {
+    } else if ("-RSB-".equals(token)) {
       return BRACKET_RSB;
     }
 
@@ -709,9 +712,8 @@ public class Parse implements Cloneable, Comparable<Parse> {
 
   /**
    * @param rest The portion of the parse string remaining to be processed.
-   *
    * @return Retrieves the string containing the token for the specified portion of the parse
-   *      string or {@code null} if the portion of the parse string does not represent a token.
+   * string or {@code null} if the portion of the parse string does not represent a token.
    */
   private static String getToken(String rest) {
     Matcher tokenMatcher = tokenPattern.matcher(rest);
@@ -735,18 +737,16 @@ public class Parse implements Cloneable, Comparable<Parse> {
       this.head = rules.getHead(parts.toArray(new Parse[0]), type);
       if (head == null) {
         head = this;
-      }
-      else {
+      } else {
         this.headIndex = head.headIndex;
       }
-    }
-    else {
+    } else {
       this.head = this;
     }
   }
 
   public void updateSpan() {
-    span = new Span((parts.get(0)).span.getStart(),(parts.get(parts.size() - 1)).span.getEnd());
+    span = new Span((parts.get(0)).span.getStart(), (parts.get(parts.size() - 1)).span.getEnd());
   }
 
   /**
@@ -763,7 +763,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
       if (children.length == 1 && node.getType().equals(children[0].getType())) {
         int index = node.getParent().parts.indexOf(node);
         children[0].setParent(node.getParent());
-        node.getParent().parts.set(index,children[0]);
+        node.getParent().parts.set(index, children[0]);
         node.parent = null;
         node.parts = null;
       }
@@ -781,12 +781,11 @@ public class Parse implements Cloneable, Comparable<Parse> {
           for (int npi = ti + 2; npi < tags.length; npi++) {
             if (tags[npi].getParent() == tags[npi - 1].getParent()) {
               end = tags[npi].getSpan().getEnd();
-            }
-            else {
+            } else {
               break;
             }
           }
-          Parse npPos = new Parse(parse.getText(), new Span(start,end), "NP", 1 , tags[ti + 1]);
+          Parse npPos = new Parse(parse.getText(), new Span(start, end), "NP", 1, tags[ti + 1]);
           parse.insert(npPos);
         }
       }
@@ -794,17 +793,15 @@ public class Parse implements Cloneable, Comparable<Parse> {
   }
 
 
-
   /**
    * Parses the specified tree-bank style parse string and return a {@link Parse} structure
    * for that string.
    *
    * @param parse A tree-bank style {@link Parse} string.
-   *
    * @return A {@link Parse} structure for the specified tree-bank style parse string.
    */
   public static Parse parseParse(String parse) {
-    return parseParse(parse,null);
+    return parseParse(parse, null);
   }
 
   /**
@@ -812,8 +809,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
    * for that string.
    *
    * @param parse A tree-bank style {@link Parse} string.
-   * @param gl The {@link GapLabeler} to be used.
-   *
+   * @param gl    The {@link GapLabeler} to be used.
    * @return A {@link Parse} structure for the specified tree-bank style parse string.
    */
   public static Parse parseParse(String parse, GapLabeler gl) {
@@ -827,24 +823,24 @@ public class Parse implements Cloneable, Comparable<Parse> {
         String rest = parse.substring(ci + 1);
         String type = getType(rest);
         if (type == null) {
-          System.err.println("null type for: " + rest);
+          logger.warn("null type for: {}", rest);
         }
         String token = getToken(rest);
-        stack.push(new Constituent(type, new Span(offset,offset)));
+        stack.push(new Constituent(type, new Span(offset, offset)));
         if (token != null) {
           if (Objects.equals(type, "-NONE-") && gl != null) {
-            //System.err.println("stack.size="+stack.size());
+            if (logger.isTraceEnabled()) {
+              logger.trace("stack.size=" + stack.size());
+            }
             gl.labelGaps(stack);
-          }
-          else {
+          } else {
             cons.add(new Constituent(AbstractBottomUpParser.TOK_NODE,
                 new Span(offset, offset + token.length())));
             text.append(token).append(" ");
             offset += token.length() + 1;
           }
         }
-      }
-      else if (c == ')') {
+      } else if (c == ')') {
         Constituent con = stack.pop();
         int start = con.getSpan().getStart();
         if (start < offset) {
@@ -854,7 +850,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
     }
     String txt = text.toString();
     int tokenIndex = -1;
-    Parse p = new Parse(txt, new Span(0, txt.length()), AbstractBottomUpParser.TOP_NODE, 1,0);
+    Parse p = new Parse(txt, new Span(0, txt.length()), AbstractBottomUpParser.TOP_NODE, 1, 0);
     for (Constituent con : cons) {
       String type = con.getLabel();
       if (!type.equals(AbstractBottomUpParser.TOP_NODE)) {
@@ -862,7 +858,9 @@ public class Parse implements Cloneable, Comparable<Parse> {
           tokenIndex++;
         }
         Parse c = new Parse(txt, con.getSpan(), type, 1, tokenIndex);
-        //System.err.println("insert["+ci+"] "+type+" "+c.toString()+" "+c.hashCode());
+        if (logger.isTraceEnabled()) {
+          logger.trace("insert[" + tokenIndex + "] " + type + " " + c + " " + c.hashCode());
+        }
         p.insert(c);
         //codeTree(p);
       }
@@ -927,9 +925,8 @@ public class Parse implements Cloneable, Comparable<Parse> {
       Parse p = nodes.remove(0);
       if (p.isPosTag()) {
         tags.add(p);
-      }
-      else {
-        nodes.addAll(0,p.parts);
+      } else {
+        nodes.addAll(0, p.parts);
       }
     }
     return tags.toArray(new Parse[0]);
@@ -942,8 +939,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
       Parse p = nodes.remove(0);
       if (p.getType().equals(AbstractBottomUpParser.TOK_NODE)) {
         tokens.add(p);
-      }
-      else {
+      } else {
         nodes.addAll(0, p.parts);
       }
     }
@@ -956,7 +952,6 @@ public class Parse implements Cloneable, Comparable<Parse> {
    * If one node is the parent of the other than the parent node is returned.
    *
    * @param node The node from which parents are compared to this node's parents.
-   *
    * @return the deepest shared parent of this node and the specified node.
    */
   public Parse getCommonParent(Parse node) {
@@ -1006,7 +1001,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
 
   /**
    * @return Retrieves the derivation string for this parse or {@code null}
-   *         if no derivation string has been created.
+   * if no derivation string has been created.
    */
   public StringBuffer getDerivation() {
     return derivation;
@@ -1021,7 +1016,7 @@ public class Parse implements Cloneable, Comparable<Parse> {
     this.derivation = derivation;
   }
 
-  private void codeTree(Parse p,int[] levels) {
+  private void codeTree(Parse p, int[] levels) {
     Parse[] kids = p.getChildren();
     StringBuilder levelsBuff = new StringBuilder();
     levelsBuff.append("[");
@@ -1032,10 +1027,10 @@ public class Parse implements Cloneable, Comparable<Parse> {
     }
     for (int ki = 0; ki < kids.length; ki++) {
       nlevels[levels.length] = ki;
-      System.out.println(levelsBuff.toString() + ki + "] " + kids[ki].getType() +
+      logger.info(levelsBuff.toString() + ki + "] " + kids[ki].getType() +
           " " + kids[ki].hashCode() + " -> " + kids[ki].getParent().hashCode() +
           " " + kids[ki].getParent().getType() + " " + kids[ki].getCoveredText());
-      codeTree(kids[ki],nlevels);
+      codeTree(kids[ki], nlevels);
     }
   }
 
@@ -1044,14 +1039,14 @@ public class Parse implements Cloneable, Comparable<Parse> {
    * contains hash codes so that parent/child relationships can be explicitly seen.
    */
   public void showCodeTree() {
-    codeTree(this,new int[0]);
+    codeTree(this, new int[0]);
   }
 
   /**
    * Utility method to insert named entities.
    *
-   * @param tag A token representing a tag.
-   * @param names An array of {@link Span names}.
+   * @param tag    A token representing a tag.
+   * @param names  An array of {@link Span names}.
    * @param tokens An array of {@link Parse tokens}.
    */
   public static void addNames(String tag, Span[] names, Parse[] tokens) {
@@ -1059,7 +1054,9 @@ public class Parse implements Cloneable, Comparable<Parse> {
       Parse startToken = tokens[nameTokenSpan.getStart()];
       Parse endToken = tokens[nameTokenSpan.getEnd() - 1];
       Parse commonParent = startToken.getCommonParent(endToken);
-      //System.err.println("addNames: "+startToken+" .. "+endToken+" commonParent = "+commonParent);
+      if (logger.isTraceEnabled()) {
+        logger.trace("addNames: " + startToken + " .. " + endToken + " commonParent = " + commonParent);
+      }
       if (commonParent != null) {
         Span nameSpan = new Span(startToken.getSpan().getStart(), endToken.getSpan().getEnd());
         if (nameSpan.equals(commonParent.getSpan())) {

--- a/opennlp-tools/src/main/java/opennlp/tools/parser/chunking/ParserEventStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/parser/chunking/ParserEventStream.java
@@ -17,7 +17,11 @@
 
 package opennlp.tools.parser.chunking;
 
+import java.util.Arrays;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.tools.dictionary.Dictionary;
 import opennlp.tools.ml.model.Event;
@@ -34,6 +38,7 @@ import opennlp.tools.util.ObjectStream;
  */
 public class ParserEventStream extends AbstractParserEventStream {
 
+  private static final Logger logger = LoggerFactory.getLogger(ParserEventStream.class);
   protected BuildContextGenerator bcg;
   protected CheckContextGenerator kcg;
 
@@ -133,7 +138,10 @@ public class ParserEventStream extends AbstractParserEventStream {
   protected void addParseEvents(List<Event> parseEvents, Parse[] chunks) {
     int ci = 0;
     while (ci < chunks.length) {
-      //System.err.println("parserEventStream.addParseEvents: chunks="+Arrays.asList(chunks));
+      if (logger.isTraceEnabled()) {
+        logger.trace("parserEventStream.addParseEvents: chunks={}", Arrays.asList(chunks));
+      }
+
       Parse c = chunks[ci];
       Parse parent = c.getParent();
       if (parent != null) {
@@ -145,8 +153,10 @@ public class ParserEventStream extends AbstractParserEventStream {
         else {
           outcome = AbstractBottomUpParser.CONT + type;
         }
-        // System.err.println("parserEventStream.addParseEvents: chunks["+ci+"]="+c+" label="
-        // +outcome+" bcg="+bcg);
+        if (logger.isTraceEnabled()) {
+          logger.trace("parserEventStream.addParseEvents: chunks[" + ci + "]="
+              + c + " label=" + outcome + " bcg=" + bcg);
+        }
         c.setLabel(outcome);
         if (etype == ParserEventTypeEnum.BUILD) {
           parseEvents.add(new Event(outcome, bcg.getContext(chunks, ci)));

--- a/opennlp-tools/src/main/java/opennlp/tools/postag/POSTaggerME.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/postag/POSTaggerME.java
@@ -25,6 +25,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.dictionary.Dictionary;
 import opennlp.tools.ml.BeamSearch;
 import opennlp.tools.ml.EventModelSequenceTrainer;
@@ -45,6 +48,7 @@ import opennlp.tools.util.StringUtil;
 import opennlp.tools.util.TrainingParameters;
 import opennlp.tools.util.featuregen.StringPattern;
 
+
 /**
  * A {@link POSTagger part-of-speech tagger} that uses maximum entropy.
  * <p>
@@ -52,6 +56,8 @@ import opennlp.tools.util.featuregen.StringPattern;
  * depending on their surrounding context.
  */
 public class POSTaggerME implements POSTagger {
+
+  private static final Logger logger = LoggerFactory.getLogger(POSTaggerME.class);
 
   public static final int DEFAULT_BEAM_SIZE = 3;
 
@@ -319,7 +325,7 @@ public class POSTaggerME implements POSTagger {
   public static void populatePOSDictionary(ObjectStream<POSSample> samples,
       MutableTagDictionary dict, int cutoff) throws IOException {
 
-    System.out.println("Expanding POS Dictionary ...");
+    logger.info("Expanding POS Dictionary ...");
     long start = System.nanoTime();
 
     // the data structure will store the word, the tag, and the number of
@@ -380,7 +386,6 @@ public class POSTaggerME implements POSTagger {
       }
     }
 
-    System.out.println("... finished expanding POS Dictionary. ["
-        + (System.nanoTime() - start) / 1000000 + "ms]");
+    logger.info("... finished expanding POS Dictionary. [ {} ms]", (System.nanoTime() - start) / 1000000 );
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/postag/WordTagSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/postag/WordTagSampleStream.java
@@ -20,6 +20,9 @@ package opennlp.tools.postag;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.FilterObjectStream;
 import opennlp.tools.util.InvalidFormatException;
 import opennlp.tools.util.ObjectStream;
@@ -29,6 +32,8 @@ import opennlp.tools.util.ObjectStream;
  * words and tags in {@code word_tag} format and outputs a {@link POSSample} objects.
  */
 public class WordTagSampleStream extends FilterObjectStream<String, POSSample> {
+
+  private static final Logger logger = LoggerFactory.getLogger(WordTagSampleStream.class);
 
   /**
    * Initializes a {@link POSSample} instance.
@@ -62,7 +67,7 @@ public class WordTagSampleStream extends FilterObjectStream<String, POSSample> {
         sample = POSSample.parse(sentence);
       } catch (InvalidFormatException e) {
         // TODO: An exception in error case should be thrown.
-        System.out.println("Error during parsing, ignoring sentence: " + sentence);
+        logger.warn("Error during parsing, ignoring sentence: {}", sentence, e);
 
         sample = new POSSample(new String[]{}, new String[]{});
       }

--- a/opennlp-tools/src/main/java/opennlp/tools/sentdetect/SentenceDetectorFactory.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/sentdetect/SentenceDetectorFactory.java
@@ -130,8 +130,6 @@ public class SentenceDetectorFactory extends BaseToolFactory {
     } catch (Exception e) {
       String msg = "Could not instantiate the " + subclassName
           + ". The initialization throw an exception.";
-      System.err.println(msg);
-      e.printStackTrace();
       throw new InvalidFormatException(msg, e);
     }
   }

--- a/opennlp-tools/src/main/java/opennlp/tools/stemmer/snowball/SnowballProgram.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/stemmer/snowball/SnowballProgram.java
@@ -32,9 +32,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package opennlp.tools.stemmer.snowball;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.InvocationTargetException;
 
 class SnowballProgram {
+
+	private static final Logger logger = LoggerFactory.getLogger(SnowballProgram.class);
+
     protected SnowballProgram()
     {
 	current = new StringBuffer();
@@ -279,10 +285,10 @@ class SnowballProgram {
 		    res = resobj.toString().equals("true");
 		} catch (InvocationTargetException e) {
 		    res = false;
-		    // FIXME - debug message
+			logger.warn(e.getLocalizedMessage(), e);
 		} catch (IllegalAccessException e) {
 		    res = false;
-		    // FIXME - debug message
+			logger.warn(e.getLocalizedMessage(), e);
 		}
 		cursor = c + w.s_size;
 		if (res) return w.result;
@@ -352,10 +358,10 @@ class SnowballProgram {
 		    res = resobj.toString().equals("true");
 		} catch (InvocationTargetException e) {
 		    res = false;
-		    // FIXME - debug message
+			logger.warn(e.getLocalizedMessage(), e);
 		} catch (IllegalAccessException e) {
 		    res = false;
-		    // FIXME - debug message
+			logger.warn(e.getLocalizedMessage(), e);
 		}
 		cursor = c - w.s_size;
 		if (res) return w.result;
@@ -389,8 +395,7 @@ class SnowballProgram {
 	    ket > limit ||
 	    limit > current.length())   // this line could be removed
 	{
-	    System.err.println("faulty slice operation");
-	// FIXME: report error somehow.
+	    logger.error("faulty slice operation");
 	/*
 	    fprintf(stderr, "faulty slice operation:\n");
 	    debug(z, -1, 0);

--- a/opennlp-tools/src/main/java/opennlp/tools/tokenize/TokSpanEventStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/tokenize/TokSpanEventStream.java
@@ -23,6 +23,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.ml.model.Event;
 import opennlp.tools.tokenize.lang.Factory;
 import opennlp.tools.util.AbstractEventStream;
@@ -36,6 +39,7 @@ import opennlp.tools.util.Span;
  */
 public class TokSpanEventStream extends AbstractEventStream<TokenSample> {
 
+  private static final Logger logger = LoggerFactory.getLogger(TokSpanEventStream.class);
   private final TokenContextGenerator cg;
 
   private final boolean skipAlphaNumerics;
@@ -134,7 +138,7 @@ public class TokSpanEventStream extends AbstractEventStream<TokenSample> {
               //keep looking
             }
             else {
-              System.out.println("Bad training token: " + tokens[ti] + " cand: " + cSpan +
+              logger.info("Bad training token: " + tokens[ti] + " cand: " + cSpan +
                   " token=" + text.substring(tokens[ti].getStart(), tokens[ti].getEnd()));
             }
           }

--- a/opennlp-tools/src/main/java/opennlp/tools/tokenize/TokenizerFactory.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/tokenize/TokenizerFactory.java
@@ -159,8 +159,6 @@ public class TokenizerFactory extends BaseToolFactory {
     } catch (Exception e) {
       String msg = "Could not instantiate the " + subclassName
           + ". The initialization throw an exception.";
-      System.err.println(msg);
-      e.printStackTrace();
       throw new InvalidFormatException(msg, e);
     }
   }

--- a/opennlp-tools/src/main/java/opennlp/tools/tokenize/lang/en/TokenSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/tokenize/lang/en/TokenSampleStream.java
@@ -26,6 +26,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.tokenize.TokenSample;
 import opennlp.tools.util.Span;
 
@@ -36,6 +39,7 @@ import opennlp.tools.util.Span;
  */
 public class TokenSampleStream implements Iterator<TokenSample> {
 
+  private static final Logger logger = LoggerFactory.getLogger(TokenSampleStream.class);
   private BufferedReader in;
   private String line;
   private Pattern alphaNumeric = Pattern.compile("[A-Za-z0-9]");
@@ -81,7 +85,6 @@ public class TokenSampleStream implements Iterator<TokenSample> {
               token.equals("(")  || token.equals("&")  || token.equals("#") ||
               (token.equals("\"") && (evenq && ti != tokens.length - 1)))
               && (!lastToken.equals("(") || !lastToken.equals("{"))) {
-            //System.out.print(" "+token);
             length++;
           }
         }
@@ -106,7 +109,7 @@ public class TokenSampleStream implements Iterator<TokenSample> {
     try {
       line = in.readLine();
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.error(e.getLocalizedMessage(), e);
       line = null;
     }
     return new TokenSample(sb.toString(),spans.toArray(new Span[0]));
@@ -118,7 +121,7 @@ public class TokenSampleStream implements Iterator<TokenSample> {
   }
 
   private static void usage() {
-    System.err.println("TokenSampleStream [-spans] < in");
-    System.err.println("Where in is a space delimited list of tokens.");
+    logger.error("TokenSampleStream [-spans] < in");
+    logger.error("Where in is a space delimited list of tokens.");
   }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/util/DownloadUtil.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/DownloadUtil.java
@@ -36,6 +36,9 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.commons.Internal;
 import opennlp.tools.util.model.BaseModel;
 
@@ -43,6 +46,8 @@ import opennlp.tools.util.model.BaseModel;
  * This class facilitates the downloading of pretrained OpenNLP models.
  */
 public class DownloadUtil {
+
+  private static final Logger logger = LoggerFactory.getLogger(DownloadUtil.class);
 
   /**
    * The type of model.
@@ -127,13 +132,13 @@ public class DownloadUtil {
     final Path localFile = Paths.get(homeDirectory.toString(), filename);
 
     if (!Files.exists(localFile)) {
-      System.out.println("Downloading model " + url + " to " + localFile);
+      logger.debug("Downloading model from {} to {}.", url, localFile);
 
       try (final InputStream in = url.openStream()) {
         Files.copy(in, localFile, StandardCopyOption.REPLACE_EXISTING);
       }
 
-      System.out.println("Download complete.");
+      logger.debug("Download complete.");
     }
 
     try {
@@ -215,7 +220,7 @@ public class DownloadUtil {
           html.append(line);
         }
       } catch (IOException e) {
-        System.err.println("Could not read page index from " + indexUrl);
+        logger.error("Could not read page index from {}", indexUrl, e);
       }
 
       return html.toString();

--- a/opennlp-tools/src/main/java/opennlp/tools/util/StringUtil.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/StringUtil.java
@@ -17,7 +17,12 @@
 
 package opennlp.tools.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class StringUtil {
+
+  private static final Logger logger = LoggerFactory.getLogger(StringUtil.class);
 
   /**
    * Determines if the specified {@link Character} is a whitespace.
@@ -252,7 +257,9 @@ public class StringUtil {
       }
       //read first letter of permutation string
       char nextOperation = permutations.charAt(permIndex);
-      //System.err.println("-> NextOP: " + nextOperation);
+      if (logger.isTraceEnabled()) {
+        logger.trace("-> NextOP: {}", nextOperation);
+      }
       //go to the next permutation letter
       permIndex++;
       if (nextOperation == 'R') {
@@ -273,7 +280,9 @@ public class StringUtil {
         if (lemma.charAt(charIndex) == replace) {
           lemma.setCharAt(charIndex, with);
         }
-        //System.err.println("-> ROP: " + lemma.toString());
+        if (logger.isTraceEnabled()) {
+          logger.trace("-> ROP: {}", lemma);
+        }
         //go to next permutation
         permIndex++;
 
@@ -288,7 +297,10 @@ public class StringUtil {
           return wordForm;
         }
         lemma.insert(charIndex, in);
-        //System.err.println("-> IOP " + lemma.toString());
+
+        if (logger.isTraceEnabled()) {
+          logger.trace("-> IOP {}", lemma);
+        }
         //go to next permutation
         permIndex++;
       } else if (nextOperation == 'D') {

--- a/opennlp-tools/src/test/java/opennlp/tools/chunker/ChunkerMETest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/chunker/ChunkerMETest.java
@@ -110,7 +110,6 @@ public class ChunkerMETest {
   @Test
   void testChunkAsSpan() {
     Span[] preds = chunker.chunkAsSpans(toks1, tags1);
-    System.out.println(Arrays.toString(preds));
 
     Assertions.assertEquals(10, preds.length);
     Assertions.assertEquals(new Span(0, 1, "NP"), preds[0]);

--- a/opennlp-tools/src/test/java/opennlp/tools/chunker/DummyChunkSampleStream.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/chunker/DummyChunkSampleStream.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.FilterObjectStream;
 import opennlp.tools.util.ObjectStream;
 
@@ -31,6 +34,8 @@ import opennlp.tools.util.ObjectStream;
  */
 public class DummyChunkSampleStream extends
     FilterObjectStream<String, ChunkSample> {
+
+  private static final Logger logger = LoggerFactory.getLogger(DummyChunkSampleStream.class);
 
   private boolean mIsPredicted;
   private int count = 0;
@@ -59,8 +64,7 @@ public class DummyChunkSampleStream extends
         .read()) {
       String[] parts = line.split(" ");
       if (parts.length != 4) {
-        System.err.println("Skipping corrupt line " + count + ": "
-            + line);
+        logger.warn("Skipping corrupt line {}: {}", count, line);
       } else {
         toks.add(parts[0]);
         posTags.add(parts[1]);

--- a/opennlp-tools/src/test/java/opennlp/tools/cmdline/CLITest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/cmdline/CLITest.java
@@ -126,7 +126,6 @@ public class CLITest {
   void testHelpMessageOfTools() {
 
     for (String toolName : CLI.getToolNames()) {
-      System.err.println("-> ToolName" + toolName);
       try {
         CLI.main(new String[] {toolName, "help"});
       } catch (ExitException e) {

--- a/opennlp-tools/src/test/java/opennlp/tools/cmdline/TokenNameFinderToolTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/cmdline/TokenNameFinderToolTest.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import opennlp.tools.cmdline.namefind.TokenNameFinderTool;
@@ -46,6 +47,10 @@ import opennlp.tools.util.TrainingParameters;
 public class TokenNameFinderToolTest {
 
   @Test
+  //TODO OPENNLP-1447
+  @Disabled(value = "OPENNLP-1447: These kind of tests won't work anymore. " +
+          "We need to find a way to redirect log output (i.e. implement " +
+          "a custom log adapter and plug it in, if we want to do such tests.")
   void run() throws IOException {
 
     File model1 = trainModel();
@@ -86,6 +91,10 @@ public class TokenNameFinderToolTest {
   }
 
   @Test
+  //TODO OPENNLP-1447
+  @Disabled(value = "OPENNLP-1447: These kind of tests won't work anymore. " +
+          "We need to find a way to redirect log output (i.e. implement " +
+          "a custom log adapter and plug it in, if we want to do such tests.")
   void usage() {
 
     String[] args = new String[] {};

--- a/opennlp-tools/src/test/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerToolTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerToolTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import opennlp.tools.AbstractTempDirTest;
@@ -82,7 +83,10 @@ public class TokenizerTrainerToolTest extends AbstractTempDirTest {
     });
   }
 
-  @Test()
+  //TODO OPENNLP-1447
+  @Disabled(value = "OPENNLP-1447: These kind of tests won't work anymore. " +
+          "We need to find a way to redirect log output (i.e. implement " +
+          "a custom log adapter and plug it in, if we want to do such tests.")
   public void testTestRunHappyCase() throws IOException {
     File model = tempDir.resolve("model-en.bin").toFile();
 
@@ -104,7 +108,10 @@ public class TokenizerTrainerToolTest extends AbstractTempDirTest {
     model.delete();
   }
 
-  @Test
+  //TODO OPENNLP-1447
+  @Disabled(value = "OPENNLP-1447: These kind of tests won't work anymore. " +
+          "We need to find a way to redirect log output (i.e. implement " +
+          "a custom log adapter and plug it in, if we want to do such tests.")
   public void testTestRunExceptionCase() throws IOException {
     File model = tempDir.resolve("model-en.bin").toFile();
     model.deleteOnExit();

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/ArvoresDeitadasEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/ArvoresDeitadasEval.java
@@ -99,7 +99,6 @@ public class ArvoresDeitadasEval extends AbstractEvalTest {
 
     cv.evaluate(samples, 10);
 
-    System.out.println(cv.getFMeasure());
     Assertions.assertEquals(expectedScore, cv.getFMeasure().getFMeasure(), 0.0001d);
   }
 
@@ -124,7 +123,6 @@ public class ArvoresDeitadasEval extends AbstractEvalTest {
 
     validator.evaluate(samples, 10);
 
-    System.out.println(validator.getFMeasure());
     Assertions.assertEquals(expectedScore, validator.getFMeasure().getFMeasure(), 0.0001d);
   }
 

--- a/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascNamedEntitySampleStreamTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascNamedEntitySampleStreamTest.java
@@ -117,7 +117,6 @@ public class MascNamedEntitySampleStreamTest extends AbstractMascSampleStreamTes
       ObjectStream<NameSample> trainSample = new MascNamedEntitySampleStream(
           new MascDocumentStream(directory, true, fileFilter));
 
-      System.out.println("Training");
       TrainingParameters trainingParameters = new TrainingParameters();
       trainingParameters.put(TrainingParameters.ITERATIONS_PARAM, 100);
 
@@ -129,15 +128,8 @@ public class MascNamedEntitySampleStreamTest extends AbstractMascSampleStreamTes
       TokenNameFinderEvaluator evaluator = new TokenNameFinderEvaluator(new NameFinderME(model));
       evaluator.evaluate(testNames);
 
-      System.out.println(evaluator.getFMeasure());
-
     } catch (Exception e) {
-      System.err.println(e.getMessage());
-      StackTraceElement[] traces = e.getStackTrace();
-      for (StackTraceElement trace : traces) {
-        System.err.println(trace.toString());
-      }
-      Assertions.fail("Exception raised");
+      Assertions.fail("Exception raised", e);
     }
   }
 

--- a/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascPOSSampleStreamTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascPOSSampleStreamTest.java
@@ -19,7 +19,6 @@ package opennlp.tools.formats.masc;
 
 import java.io.FileFilter;
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,7 +109,6 @@ public class MascPOSSampleStreamTest extends AbstractMascSampleStreamTest {
       ObjectStream<POSSample> trainPOS = new MascPOSSampleStream(
           new MascDocumentStream(directory, true, fileFilter));
 
-      System.out.println("Training");
       POSModel model = null;
       TrainingParameters trainingParameters = new TrainingParameters();
       trainingParameters.put(TrainingParameters.ITERATIONS_PARAM, 20);
@@ -122,13 +120,9 @@ public class MascPOSSampleStreamTest extends AbstractMascSampleStreamTest {
               new MascDocumentStream(directory, true, fileFilter));
       POSEvaluator evaluator = new POSEvaluator(new POSTaggerME(model));
       evaluator.evaluate(testPOS);
-      System.out.println("Accuracy: " + evaluator.getWordAccuracy());
-      System.out.println("Words: " + evaluator.getWordCount());
 
     } catch (Exception e) {
-      System.err.println(e.getMessage());
-      System.err.println(Arrays.toString(e.getStackTrace()));
-      Assertions.fail("Exception raised");
+      Assertions.fail("Exception raised", e);
     }
 
   }

--- a/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascSentenceSampleStreamTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascSentenceSampleStreamTest.java
@@ -20,7 +20,6 @@ package opennlp.tools.formats.masc;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -113,9 +112,7 @@ public class MascSentenceSampleStreamTest extends AbstractMascSampleStreamTest {
       Assertions.assertNull(testSample);
 
     } catch (IOException e) {
-      System.out.println(e.getMessage());
-      System.out.println(Arrays.toString(e.getStackTrace()));
-      Assertions.fail("IO Exception");
+      Assertions.fail("IO Exception", e);
     }
 
   }
@@ -129,7 +126,6 @@ public class MascSentenceSampleStreamTest extends AbstractMascSampleStreamTest {
           new MascDocumentStream(directory,
               true, fileFilter), 1);
 
-      System.out.println("Training");
       SentenceModel model = null;
       TrainingParameters trainingParameters = new TrainingParameters();
       trainingParameters.put(TrainingParameters.ITERATIONS_PARAM, 20);
@@ -142,12 +138,9 @@ public class MascSentenceSampleStreamTest extends AbstractMascSampleStreamTest {
       SentenceDetectorEvaluator evaluator = new SentenceDetectorEvaluator(
           new SentenceDetectorME(model));
       evaluator.evaluate(testPOS);
-      System.out.println(evaluator.getFMeasure());
 
     } catch (Exception e) {
-      System.err.println(e.getMessage());
-      System.err.println(Arrays.toString(e.getStackTrace()));
-      Assertions.fail("Exception raised");
+      Assertions.fail("Exception raised", e);
     }
 
 

--- a/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascTokenSampleStreamTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/formats/masc/MascTokenSampleStreamTest.java
@@ -19,7 +19,6 @@ package opennlp.tools.formats.masc;
 
 import java.io.FileFilter;
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,7 +129,6 @@ public class MascTokenSampleStreamTest extends AbstractMascSampleStreamTest {
       ObjectStream<TokenSample> trainTokens = new MascTokenSampleStream(
           new MascDocumentStream(directory, true, fileFilter));
 
-      System.out.println("Training");
       TokenizerModel model = null;
       TrainingParameters trainingParameters = new TrainingParameters();
       trainingParameters.put(TrainingParameters.ITERATIONS_PARAM, 20);
@@ -142,12 +140,9 @@ public class MascTokenSampleStreamTest extends AbstractMascSampleStreamTest {
           new MascDocumentStream(directory, true, fileFilter));
       TokenizerEvaluator evaluator = new TokenizerEvaluator(new TokenizerME(model));
       evaluator.evaluate(testTokens);
-      System.out.println(evaluator.getFMeasure());
 
     } catch (Exception e) {
-      System.err.println(e.getMessage());
-      System.err.println(Arrays.toString(e.getStackTrace()));
-      Assertions.fail("Exception raised");
+      Assertions.fail("Exception raised", e);
     }
 
   }

--- a/opennlp-tools/src/test/java/opennlp/tools/lemmatizer/DummyLemmaSampleStream.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/lemmatizer/DummyLemmaSampleStream.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import opennlp.tools.util.FilterObjectStream;
 import opennlp.tools.util.ObjectStream;
 
@@ -32,6 +35,7 @@ import opennlp.tools.util.ObjectStream;
 public class DummyLemmaSampleStream
     extends FilterObjectStream<String, LemmaSample> {
 
+  private static final Logger logger = LoggerFactory.getLogger(DummyLemmaSampleStream.class);
   private boolean mIsPredicted;
   private int count = 0;
 
@@ -54,7 +58,7 @@ public class DummyLemmaSampleStream
         && !line.equals(""); line = samples.read()) {
       String[] parts = line.split("\t");
       if (parts.length != 4) {
-        System.err.println("Skipping corrupt line " + count + ": " + line);
+        logger.warn("Skipping corrupt line {}: {}", count, line);
       } else {
         toks.add(parts[0]);
         posTags.add(parts[1]);

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/PrepAttachDataUtil.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/PrepAttachDataUtil.java
@@ -85,7 +85,6 @@ public class PrepAttachDataUtil {
     }
 
     double accuracy = correct / (double) total;
-    System.out.println("Accuracy on PPA devset: (" + correct + "/" + total + ") " + accuracy);
 
     Assertions.assertEquals(expecedAccuracy, accuracy, .00001);
   }

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/GISIndexingTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/GISIndexingTest.java
@@ -132,7 +132,6 @@ public class GISIndexingTest {
       params.put(AbstractTrainer.ITERATIONS_PARAM, 10);
       params.put(AbstractTrainer.CUTOFF_PARAM, 1);
       params.put("smoothing", false);
-      params.put(AbstractTrainer.VERBOSE_PARAM, false);
 
       EventTrainer trainer = TrainerFactory.getEventTrainer(params, null);
       Assertions.assertNotNull(trainer.train(eventStream));

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/MaxentPrepAttachTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/MaxentPrepAttachTest.java
@@ -56,7 +56,7 @@ public class MaxentPrepAttachTest {
     // TODO: make sure that the trainingParameter cutoff and the 
     // cutoff value passed here are equal.
     AbstractModel model =
-        new GISTrainer(true).trainModel(100,
+        new GISTrainer().trainModel(100,
             testDataIndexer,
             new UniformPrior(), 1);
     PrepAttachDataUtil.testModel(model, 0.7997028967566229);
@@ -66,7 +66,7 @@ public class MaxentPrepAttachTest {
   void testMaxentOnPrepAttachData2Threads() throws IOException {
     testDataIndexer.index(PrepAttachDataUtil.createTrainingStream());
     AbstractModel model =
-        new GISTrainer(true).trainModel(100,
+        new GISTrainer().trainModel(100,
             testDataIndexer,
             new UniformPrior(), 2);
     PrepAttachDataUtil.testModel(model, 0.7997028967566229);

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/RealValueModelTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/RealValueModelTest.java
@@ -67,10 +67,6 @@ public class RealValueModelTest {
 
     Assertions.assertEquals(realResults.length, repeatResults.length);
     for (int i = 0; i < realResults.length; i++) {
-      System.out.println(String.format("classifiy with realModel: %1$s = %2$f",
-          realModel.getOutcome(i), realResults[i]));
-      System.out.println(String.format("classifiy with repeatModel: %1$s = %2$f",
-          repeatModel.getOutcome(i), repeatResults[i]));
       Assertions.assertEquals(repeatResults[i], realResults[i], 0.01f);
     }
 
@@ -78,13 +74,8 @@ public class RealValueModelTest {
     realResults = realModel.eval(features2Classify, new float[] {5.5f, 6.1f, 9.1f, 4.0f, 1.8f});
     repeatResults = repeatModel.eval(features2Classify, new float[] {5.5f, 6.1f, 9.1f, 4.0f, 1.8f});
 
-    System.out.println();
     Assertions.assertEquals(realResults.length, repeatResults.length);
     for (int i = 0; i < realResults.length; i++) {
-      System.out.println(String.format("classifiy with realModel: %1$s = %2$f",
-          realModel.getOutcome(i), realResults[i]));
-      System.out.println(String.format("classifiy with repeatModel: %1$s = %2$f",
-          repeatModel.getOutcome(i), repeatResults[i]));
       Assertions.assertEquals(repeatResults[i],  realResults[i],0.01f);
     }
 

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/ScaleDoesntMatterTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/ScaleDoesntMatterTest.java
@@ -80,7 +80,6 @@ public class ScaleDoesntMatterTest {
     double[] smallResults = smallModel.eval(contexts, values);
 
     String smallResultString = smallModel.getAllOutcomes(smallResults);
-    System.out.println("smallResults: " + smallResultString);
 
     ObjectStream<Event> largeEventStream = new RealBasicEventStream(
         new PlainTextByLineStream(new MockInputStreamFactory(largeValues), StandardCharsets.UTF_8));
@@ -96,16 +95,9 @@ public class ScaleDoesntMatterTest {
     double[] largeResults = largeModel.eval(contexts, values);
 
     String largeResultString = largeModel.getAllOutcomes(largeResults);
-    System.out.println("largeResults: " + largeResultString);
 
     Assertions.assertEquals(smallResults.length, largeResults.length);
     for (int i = 0; i < smallResults.length; i++) {
-      System.out.println(String.format(
-          "classifiy with smallModel: %1$s = %2$f", smallModel.getOutcome(i),
-          smallResults[i]));
-      System.out.println(String.format(
-          "classifiy with largeModel: %1$s = %2$f", largeModel.getOutcome(i),
-          largeResults[i]));
       Assertions.assertEquals(largeResults[i], smallResults[i], 0.01f);
     }
   }

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/quasinewton/QNPrepAttachTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/quasinewton/QNPrepAttachTest.java
@@ -44,7 +44,7 @@ public class QNPrepAttachTest {
     indexer.init(indexingParameters, new HashMap<>());
     indexer.index(PrepAttachDataUtil.createTrainingStream());
 
-    AbstractModel model = new QNTrainer(true).trainModel(100, indexer);
+    AbstractModel model = new QNTrainer().trainModel(100, indexer);
 
     PrepAttachDataUtil.testModel(model, 0.8155484030700668);
   }

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/quasinewton/QNTrainerTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/maxent/quasinewton/QNTrainerTest.java
@@ -58,7 +58,7 @@ public class QNTrainerTest {
         "src/test/resources/data/opennlp/maxent/real-valued-weights-training-data.txt");
     testDataIndexer.index(rvfes1);
     // when
-    QNModel trainedModel = new QNTrainer(false).trainModel(ITERATIONS, testDataIndexer);
+    QNModel trainedModel = new QNTrainer().trainModel(ITERATIONS, testDataIndexer);
     // then
     Assertions.assertNotNull(trainedModel);
   }
@@ -70,7 +70,7 @@ public class QNTrainerTest {
         "src/test/resources/data/opennlp/maxent/real-valued-weights-training-data.txt");
     testDataIndexer.index(rvfes1);
     // when
-    QNModel trainedModel = new QNTrainer(15, true).trainModel(ITERATIONS, testDataIndexer);
+    QNModel trainedModel = new QNTrainer(15).trainModel(ITERATIONS, testDataIndexer);
     String[] features2Classify = new String[] {
         "feature2", "feature3", "feature3",
         "feature3", "feature3", "feature3",
@@ -88,7 +88,7 @@ public class QNTrainerTest {
         "src/test/resources/data/opennlp/maxent/real-valued-weights-training-data.txt");
     testDataIndexer.index(rvfes1);
     // when
-    QNModel trainedModel = new QNTrainer(15, true).trainModel(
+    QNModel trainedModel = new QNTrainer(15).trainModel(
         ITERATIONS, testDataIndexer);
 
     Assertions.assertNotEquals(null, trainedModel);
@@ -101,7 +101,7 @@ public class QNTrainerTest {
         "src/test/resources/data/opennlp/maxent/real-valued-weights-training-data.txt");
     testDataIndexer.index(rvfes1);
     // when
-    QNModel trainedModel = new QNTrainer(5, 700, true).trainModel(ITERATIONS, testDataIndexer);
+    QNModel trainedModel = new QNTrainer(5, 700).trainModel(ITERATIONS, testDataIndexer);
 
     ByteArrayOutputStream modelBytes = new ByteArrayOutputStream();
     GenericModelWriter modelWriter = new GenericModelWriter(trainedModel,

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/model/OnePassRealValueDataIndexerTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/model/OnePassRealValueDataIndexerTest.java
@@ -93,7 +93,6 @@ public class OnePassRealValueDataIndexerTest {
         .build();
 
     indexer.index(eventStream);
-    System.out.println(indexer);
     Assertions.assertEquals(3, indexer.getContexts().length);
     Assertions.assertArrayEquals(new int[] {0}, indexer.getContexts()[0]);
     Assertions.assertArrayEquals(new int[] {0}, indexer.getContexts()[1]);

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/naivebayes/NaiveBayesSerializedCorrectnessTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/naivebayes/NaiveBayesSerializedCorrectnessTest.java
@@ -146,7 +146,6 @@ public class NaiveBayesSerializedCorrectnessTest {
     modelWriter = new PlainTextNaiveBayesModelWriter(model2, new BufferedWriter(sw2));
     modelWriter.persist();
 
-    System.out.println(sw1.toString());
     Assertions.assertEquals(sw1.toString(), sw2.toString());
 
   }

--- a/opennlp-uima/pom.xml
+++ b/opennlp-uima/pom.xml
@@ -42,12 +42,6 @@
 		</repository>
 	</repositories>
 
-	<properties>
-		<!--This property should be aligned with the version UIMA uses-->
-		<slf4j.version>1.7.36</slf4j.version>
-	</properties>
-
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.opennlp</groupId>
@@ -59,6 +53,11 @@
 			<artifactId>uimaj-core</artifactId>
 			<version>3.3.1</version>
 			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>
@@ -83,7 +82,6 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/opennlp-uima/src/main/java/opennlp/uima/chunker/Chunker.java
+++ b/opennlp-uima/src/main/java/opennlp/uima/chunker/Chunker.java
@@ -30,6 +30,7 @@ import org.apache.uima.resource.ResourceAccessException;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.util.Level;
 import org.apache.uima.util.Logger;
+import org.slf4j.LoggerFactory;
 
 import opennlp.tools.chunker.ChunkerME;
 import opennlp.tools.chunker.ChunkerModel;
@@ -60,6 +61,7 @@ import opennlp.uima.util.UimaUtil;
  */
 public final class Chunker extends CasAnnotator_ImplBase {
 
+  private static org.slf4j.Logger logger = LoggerFactory.getLogger(Chunker.class);
   /**
    * The chunk type parameter.
    */
@@ -212,7 +214,7 @@ public final class Chunker extends CasAnnotator_ImplBase {
           end = -1;
         }
       } else {
-        System.out.println("Unexpected tag: " + result[i]);
+        logger.warn("Unexpected tag: {}", result[i]);
       }
     }
 

--- a/opennlp-uima/src/test/java/opennlp/uima/dictionary/DictionaryResourceTest.java
+++ b/opennlp-uima/src/test/java/opennlp/uima/dictionary/DictionaryResourceTest.java
@@ -111,7 +111,6 @@ public class DictionaryResourceTest {
       }
       Assertions.assertEquals(0, expectedLocations.size());
     } catch (Exception e) {
-      e.printStackTrace();
       Assertions.fail(e.getLocalizedMessage());
     }
 

--- a/opennlp-uima/src/test/java/opennlp/uima/util/CasUtil.java
+++ b/opennlp-uima/src/test/java/opennlp/uima/util/CasUtil.java
@@ -37,9 +37,13 @@ import org.apache.uima.util.CasCreationUtils;
 import org.apache.uima.util.InvalidXMLException;
 import org.apache.uima.util.XMLInputSource;
 import org.apache.uima.util.XMLParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 public class CasUtil {
+
+  private static final Logger logger = LoggerFactory.getLogger(CasUtil.class);
 
   public static TypeSystemDescription createTypeSystemDescription(InputStream in) {
 
@@ -59,7 +63,7 @@ public class CasUtil {
 
       typeSystemDesciptor.resolveImports();
     } catch (InvalidXMLException e) {
-      e.printStackTrace();
+      logger.error(e.getLocalizedMessage(), e);
       typeSystemDesciptor = null;
     }
 
@@ -82,7 +86,7 @@ public class CasUtil {
       cas = CasCreationUtils.createCas(typeSystem, typePriorities,
           new FsIndexDescription[] { indexDesciptor });
     } catch (ResourceInitializationException e) {
-      e.printStackTrace();
+      logger.error(e.getLocalizedMessage(), e);
       cas = null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,19 @@
 		<dependencies>
 
 			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-simple</artifactId>
+				<version>${slf4j.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-api</artifactId>
 				<version>${junit.version}</version>
@@ -160,6 +173,8 @@
 		<morfologik.version>2.1.7</morfologik.version>
 		<checkstyle.plugin.version>3.2.0</checkstyle.plugin.version>
 		<onnxruntime.version>1.14.0</onnxruntime.version>
+		<slf4j.version>1.7.36</slf4j.version>
+		<log4j2.version>2.19.0</log4j2.version>
 		<opennlp.forkCount>1.0C</opennlp.forkCount>
 		<coveralls.maven.plugin>4.3.0</coveralls.maven.plugin>
 		<jacoco.maven.plugin>0.7.9</jacoco.maven.plugin>
@@ -270,7 +285,7 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>${maven.surefire.plugin}</version>
 					<configuration>
-						<argLine>-Xmx2048m</argLine>
+						<argLine>-Xmx2048m -Dorg.slf4j.simpleLogger.defaultLogLevel=off</argLine>
 						<forkCount>${opennlp.forkCount}</forkCount>
 						<failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
 						<excludes>


### PR DESCRIPTION
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:

This PR is the first sub-task of [OPENNLP-1447](https://issues.apache.org/jira/browse/OPENNLP-1447).

- It introduces `slf4j-api` in OpenNLP and replaces calls to `System.err` or `System.out` by related logger calls.
- It adds `log4j2` as `runtime` dependency to the OpenNLP distribution + related configuration and adjusts the scripts accordingly

#### Notes for reviewers:

- Revision of log levels is tracked with [OPENNLP-1449](https://issues.apache.org/jira/browse/OPENNLP-1449) and is not scope of the given PR. However, comments on specific log levels are highly welcome, so they can be tracked and incorporated in OPENNLP-1449.
- Fully use of formatting using the possibilities of SLF4J eg.`{}`-replacement is tracked with [OPENNLP-1450](https://issues.apache.org/jira/browse/OPENNLP-1450) and is not scope of the given PR.
- Log output reduction during the build is currently tracked with  [OPENNLP-1451](https://issues.apache.org/jira/browse/OPENNLP-1451). At the moment, I introduced `slf4j-simple` as a `test` dependency and disabled log output. We can discuss how we want to deal with it within OPENNLP-1451.
- If some removed `System.out / System.err` statements (in the tests) are really needed, please leave a comment. We can easily move them to log statements

#### TODOs for reviewers:

- It would be great, if our heavy CLI users like @atarora can provide valuable feedback.
- Due to the absence of a Windows machine, I cannot test the `.bat` changes - maybe some Windows user can have a look here.
- It would be great, if someone with the `eval` datasets available on his/her machine can run the `eval` tests and provide feedback, if needed.
- I disabled a few tests, which relied on overriding `System.out` and gathering the output. Happy to receive ideas on how we can re-write them to work with `slf4j-simple` in the test context


![image](https://user-images.githubusercontent.com/13417392/213663341-0e8a76fa-188b-4137-90e5-4c3f9427a303.png)

