### PR TITLE
OPENNLP-1459: Updating eval test expected values due to fix in OPENNLP-1332

### DIFF
--- a/opennlp-tools/src/test/java/opennlp/tools/eval/ArvoresDeitadasEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/ArvoresDeitadasEval.java
@@ -209,7 +209,7 @@ public class ArvoresDeitadasEval extends AbstractEvalTest {
   @Test
   void evalPortugueseChunkerQn() throws IOException {
     chunkerCrossEval(createMaxentQnParams(),
-        0.9648211936491359d);
+        0.9651009811896799d);
   }
 
   @Test

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/SourceForgeModelEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/SourceForgeModelEval.java
@@ -342,7 +342,7 @@ public class SourceForgeModelEval extends AbstractEvalTest {
       }
     }
 
-    Assertions.assertEquals(new BigInteger("226003515785585284478071030961407561943"),
+    Assertions.assertEquals(new BigInteger("304922886851384639120257052245406261332"),
         new BigInteger(1, digest.digest()));
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/OPENNLP-1459. The need for this was due to the fix in https://issues.apache.org/jira/browse/OPENNLP-1332.