### PR TITLE
OPENNLP-1471 Ensure Dictionary#asStringSet() implements hashCode() and equals() correctly

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/dictionary/Dictionary.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/dictionary/Dictionary.java
@@ -343,8 +343,36 @@ public class Dictionary implements Iterable<StringList>, SerializableArtifact {
           result = entrySet.contains(new StringListWrapper(new StringList(str)));
 
         }
-
         return result;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        if (! (o instanceof Set)) {
+          return false;
+        }
+        Set<String> toCheck = (Set<String>) o;
+        if (entrySet.size() != toCheck.size()) {
+          return false;
+        }
+        Iterator<String> toCheckIter = toCheck.iterator();
+        for (StringListWrapper entry : entrySet) {
+          if (isCaseSensitive) {
+            if (!entry.stringList.equals(new StringList(toCheckIter.next()))) {
+              return false;
+            }
+          } else {
+            if (!entry.stringList.compareToIgnoreCase(new StringList(toCheckIter.next()))) {
+              return false;
+            }
+          }
+        }
+        return true;
+      }
+
+      @Override
+      public int hashCode() {
+        return entrySet.hashCode();
       }
     };
   }

--- a/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseInsensitiveTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseInsensitiveTest.java
@@ -143,7 +143,7 @@ public class DictionaryAsSetCaseInsensitiveTest {
   }
 
   /**
-   * Tests the {@link Dictionary#hashCode()} method.
+   * Tests the {@link Dictionary#asStringSet()#hashCode()} method without case changes.
    */
   @Test
   void testHashCode() {
@@ -152,18 +152,19 @@ public class DictionaryAsSetCaseInsensitiveTest {
     Dictionary dictA = getDict();
     dictA.put(asSL(entry1));
 
-    Set<String> setA = dictA.asStringSet();
-
     Dictionary dictB = getDict();
     dictB.put(asSL(entry1));
 
+    Assertions.assertEquals(dictA.hashCode(), dictB.hashCode());
+
+    Set<String> setA = dictA.asStringSet();
     Set<String> setB = dictB.asStringSet();
 
     Assertions.assertEquals(setA.hashCode(), setB.hashCode());
   }
 
   /**
-   * Tests the {@link Dictionary#hashCode()} method.
+   * Tests the {@link Dictionary#asStringSet()#hashCode()}} method with case changes.
    */
   @Test
   void testHashCodeDifferentCase() {
@@ -172,15 +173,15 @@ public class DictionaryAsSetCaseInsensitiveTest {
     Dictionary dictA = getDict();
     dictA.put(asSL(entry1));
 
-    Set<String> setA = dictA.asStringSet();
-
     Dictionary dictB = getDict();
-    dictB.put(asSL(entry1.toUpperCase()));
+    dictB.put(asSL(entry1.toUpperCase())); // adjusting entry to differ case-wise.
 
+    Assertions.assertEquals(dictA.hashCode(), dictB.hashCode());
+
+    Set<String> setA = dictA.asStringSet();
     Set<String> setB = dictB.asStringSet();
 
-    // TODO: should it be equal??
-    Assertions.assertNotSame(setA.hashCode(), setB.hashCode());
+    Assertions.assertEquals(setA.hashCode(), setB.hashCode());
   }
 
   /**

--- a/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseSensitiveTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseSensitiveTest.java
@@ -144,7 +144,7 @@ public class DictionaryAsSetCaseSensitiveTest {
   }
 
   /**
-   * Tests the {@link Dictionary#hashCode()} method.
+   * Tests the {@link Dictionary#asStringSet()#hashCode()} method.
    */
   @Test
   void testHashCode() {
@@ -164,7 +164,7 @@ public class DictionaryAsSetCaseSensitiveTest {
   }
 
   /**
-   * Tests the {@link Dictionary#hashCode()} method.
+   * Tests the {@link Dictionary#asStringSet()#hashCode()} method.
    */
   @Test
   void testHashCodeDifferentCase() {
@@ -180,8 +180,7 @@ public class DictionaryAsSetCaseSensitiveTest {
 
     Set<String> setB = dictB.asStringSet();
 
-    // TODO: should it be equal??
-    Assertions.assertNotSame(setA.hashCode(), setB.hashCode());
+    Assertions.assertEquals(setA.hashCode(), setB.hashCode());
   }
 
   /**


### PR DESCRIPTION
Change
-

- adds missing equals and hashCode implementations
- cures existing TODOS in related test cases

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
