### PR TITLE
OPENNLP-1229 PorterStemmer stem function giving wrong output

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/stemmer/PorterStemmer.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/stemmer/PorterStemmer.java
@@ -44,12 +44,12 @@
 package opennlp.tools.stemmer;
 
 /**
- *
- * Stemmer, implementing the Porter Stemming Algorithm
- *
- * The Stemmer class transforms a word into its root form.  The input
- * word can be provided a character at time (by calling add()), or at once
- * by calling one of the various stem(something) methods.
+ * A {@link Stemmer}, implementing the <a href="https://tartarus.org/martin/PorterStemmer/">
+ * Porter Stemming Algorithm</a>
+ * <p>
+ * The Stemmer implementation transforms a word into its root form. The input
+ * word can be provided a character at time (by calling {@link #add(char)}),
+ * or at once by calling one of the various {@code stem(..)} methods.
  */
 // CHECKSTYLE:OFF
 public class PorterStemmer implements Stemmer {

--- a/opennlp-tools/src/test/java/opennlp/tools/stemmer/PorterStemmerTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/stemmer/PorterStemmerTest.java
@@ -18,23 +18,38 @@
 package opennlp.tools.stemmer;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class PorterStemmerTest {
 
-  private PorterStemmer stemmer = new PorterStemmer();
+  private PorterStemmer stemmer;
 
-  @Test
-  void testNotNull() {
-    Assertions.assertNotNull(stemmer);
+  @BeforeEach
+  public void setup() {
+    stemmer = new PorterStemmer();
   }
 
   @Test
-  void testStemming() {
-    Assertions.assertEquals(stemmer.stem("deny"), "deni");
-    Assertions.assertEquals(stemmer.stem("declining"), "declin");
-    Assertions.assertEquals(stemmer.stem("diversity"), "divers");
-    Assertions.assertEquals(stemmer.stem("divers"), "diver");
-    Assertions.assertEquals(stemmer.stem("dental"), "dental");
+  void testStem() {
+    Assertions.assertEquals("deni", stemmer.stem("deny"));
+    Assertions.assertEquals("declin", stemmer.stem("declining"));
+    Assertions.assertEquals("divers", stemmer.stem("diversity"));
+    Assertions.assertEquals("diver", stemmer.stem("divers"));
+    Assertions.assertEquals("dental", stemmer.stem("dental"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"likes", "liked", "likely", "liking"})
+  void testStemLike(String input) {
+    Assertions.assertEquals("like", stemmer.stem(input));
+  }
+
+
+  @Test // Context: OpenNLP-1229 - This is here to demonstrate & verify.
+  void testStemThis() {
+    Assertions.assertEquals("thi", stemmer.stem("this"));
   }
 }

--- a/opennlp-tools/src/test/java/opennlp/tools/stemmer/SnowballStemmerTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/stemmer/SnowballStemmerTest.java
@@ -69,6 +69,12 @@ public class SnowballStemmerTest {
 
   }
 
+  @Test // Context: OpenNLP-1229 - This is here to demonstrate & verify.
+  void testStemThis() {
+    SnowballStemmer stemmer = new SnowballStemmer(ALGORITHM.ENGLISH);
+    Assertions.assertEquals("this", stemmer.stem("this"));
+  }
+
   @Test
   void testFinnish() {
     SnowballStemmer stemmer = new SnowballStemmer(ALGORITHM.FINNISH);


### PR DESCRIPTION
Change
-
- adds unit test to verify "this" is stemmed to "thi", as expected for `PorterStemmer`
- adds unit test to verify "this" is stemmed to "this" for `SnowballStemmer`
- adds additional `ParameterizedTest` in `PorterStemmerTest`
- improves JavaDoc along the path

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
