### PR TITLE
OPENNLP-1333 Write unit test for parser top "k" parses

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/parser/Parse.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/parser/Parse.java
@@ -450,6 +450,15 @@ public class Parse implements Cloneable, Comparable<Parse> {
   }
 
   /**
+   * @return Retrieves a String representation using Penn Treebank-style formatting.
+   */
+  public String toStringPennTreebank() {
+    StringBuffer buffer = new StringBuffer();
+    show(buffer);
+    return buffer.toString();
+  }
+
+  /**
    * Represents this {@link Parse} in a human-readable way.
    */
   @Override

--- a/opennlp-tools/src/test/java/opennlp/tools/parser/AbstractParserModelTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/parser/AbstractParserModelTest.java
@@ -20,6 +20,9 @@ package opennlp.tools.parser;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -27,7 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import opennlp.tools.tokenize.WhitespaceTokenizer;
 import opennlp.tools.util.Span;
 
 /**
@@ -84,6 +89,59 @@ public abstract class AbstractParserModelTest {
     Assertions.assertEquals(reference, p.getText());
     Span s = parsedViaParser.getSpan();
     Assertions.assertNotNull(s);
+  }
+
+  /*
+   * Verifies changes in OPENNLP-1330 and addresses follow-up OPENNLP-1333
+   * See: https://issues.apache.org/jira/projects/OPENNLP/issues/OPENNLP-1333
+   *
+   * Uses test data from PR 392 (https://github.com/apache/opennlp/pull/392).
+   */
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3})
+  void testParsingTopParses(int k) {
+    // fixtures
+    final String sent = "Eric is testing.";
+    final String refParseTopChunking =
+            "(TOP (S (NP (NNP Eric)) (VP (VBZ is) (NP (DT testing.)))))";
+    final String refParseTopTreeInsert =
+            "(TOP (S (NP (NNP Eric)) (VP (VBZ is) (NN testing.))))";
+
+    // prepare
+    List<String> tokens = Arrays.asList(WhitespaceTokenizer.INSTANCE.tokenize(sent));
+    String text = String.join(" ", tokens);
+
+    Parse sentP = new Parse(text, new Span(0, text.length()),
+            AbstractBottomUpParser.INC_NODE, 0, 0);
+    int start = 0;
+    int i = 0;
+    for (Iterator<String> ti = tokens.iterator(); ti.hasNext(); i++) {
+      String tok = ti.next();
+      sentP.insert(new Parse(text, new Span(start, start + tok.length()),
+              AbstractBottomUpParser.TOK_NODE, 0, i));
+      start += tok.length() + 1;
+    }
+
+    opennlp.tools.parser.Parser parser = ParserFactory.create(getModel());
+    Assertions.assertNotNull(parser);
+
+    // TEST: parsing
+    Parse[] parses = parser.parse(sentP, k);
+    Assertions.assertNotNull(parses);
+    Assertions.assertEquals(k, parses.length);
+    double previousProb = 0; // initial ref value
+    for (int j = 0; j < parses.length; j++) {
+      Assertions.assertTrue(parses[j].getProb() < previousProb);
+      String asPennTreebankStyle = parses[j].toStringPennTreebank();
+      // System.out.println(parses[j].getProb() + " - " + asPennTreebankStyle);
+      if (j == 0) {
+        if (ParserType.CHUNKING.equals(getModel().getParserType())) {
+          Assertions.assertEquals(refParseTopChunking, asPennTreebankStyle);
+        } else if (ParserType.TREEINSERT.equals(getModel().getParserType())) {
+          Assertions.assertEquals(refParseTopTreeInsert, asPennTreebankStyle);
+        }
+      }
+    }
   }
 
   /*


### PR DESCRIPTION
Change
-
- provides new test cases for `k = 1, 2, 3` for both Parser implementations
- uses test data from https://github.com/apache/opennlp/pull/392
- adds `toStringPennTreebank` in `Parse` to obtain a uniform string representation for verification or comparison

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
