### PR TITLE
OPENNLP-509 opennlp.tools.parser.Parse.getParent() returning incorrect object

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/parser/AbstractBottomUpParser.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/parser/AbstractBottomUpParser.java
@@ -338,15 +338,30 @@ public abstract class AbstractBottomUpParser implements Parser {
       odh = ndh;
     }
     if (completeParses.size() == 0) {
+      if (guess != null) {
+        setParents(guess);
+        for (Parse childGuess: guess.getChildren()) {
+          setParents(childGuess);
+        }
+      }
       return new Parse[] {guess};
     }
     else if (numParses == 1) {
-      return new Parse[] {completeParses.first()};
+      Parse best = completeParses.first();
+      setParents(best);
+      for (Parse childBest: best.getChildren()) {
+        setParents(childBest);
+      }
+      return new Parse[] {best};
     }
     else {
       List<Parse> topParses = new ArrayList<>(numParses);
       while (!completeParses.isEmpty() && topParses.size() < numParses) {
         Parse tp = completeParses.first();
+        setParents(tp);
+        for (Parse childTp: tp.getChildren()) {
+          setParents(childTp);
+        }
         completeParses.remove(tp);
         topParses.add(tp);
         //parses.remove(tp);


### PR DESCRIPTION
Change
-
- adds `setParents(..)` calls in `AbstractBottomUpParser#parse(Parse tokens, int numParses)` which now set the hierarchical (back) references that were missing before
- adds test to verify that a processed Parse instance's parent references are populated and _not_ `null`

Notes
-
- [OpenNLP-509](https://issues.apache.org/jira/projects/OPENNLP/issues/OPENNLP-509) was open for 10+ years.

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
