### PR TITLE
OPENNLP-1481 - Address failing ONNX Runtime tests

### DIFF
--- a/opennlp-dl/src/test/java/opennlp/dl/AbstractDLTest.java
+++ b/opennlp-dl/src/test/java/opennlp/dl/AbstractDLTest.java
@@ -22,11 +22,11 @@ import java.io.FileNotFoundException;
 
 import opennlp.tools.util.StringUtil;
 
-public abstract class AbstactDLTest {
+public abstract class AbstractDLTest {
 
   public static File getOpennlpDataDir() throws FileNotFoundException {
     final String dataDirectory = System.getProperty("OPENNLP_DATA_DIR");
-    if (StringUtil.isEmpty(dataDirectory)) {
+    if (dataDirectory == null || StringUtil.isEmpty(dataDirectory)) {
       throw new IllegalArgumentException("The OPENNLP_DATA_DIR is not set.");
     }
     final File file = new File(dataDirectory);

--- a/opennlp-dl/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
+++ b/opennlp-dl/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,11 +33,11 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import opennlp.dl.AbstactDLTest;
+import opennlp.dl.AbstractDLTest;
 import opennlp.dl.InferenceOptions;
 import opennlp.dl.doccat.scoring.AverageClassificationScoringStrategy;
 
-public class DocumentCategorizerDLEval extends AbstactDLTest {
+public class DocumentCategorizerDLEval extends AbstractDLTest {
 
   private static final Logger logger = LoggerFactory.getLogger(DocumentCategorizerDLEval.class);
 
@@ -174,11 +175,11 @@ public class DocumentCategorizerDLEval extends AbstactDLTest {
 
     final Map<String, Double> result = documentCategorizerDL.scoreMap(new String[]{"I am happy"});
 
-    Assertions.assertEquals(0.6352779865264893, result.get("very good").doubleValue(), 0.000001);
-    Assertions.assertEquals(0.3003573715686798, result.get("good").doubleValue(), 0.000001);
-    Assertions.assertEquals(0.04995147883892059, result.get("neutral").doubleValue(), 0.000001);
-    Assertions.assertEquals(0.006593209225684404, result.get("bad").doubleValue(), 0.000001);
-    Assertions.assertEquals(0.007819971069693565, result.get("very bad").doubleValue(), 0.000001);
+    Assertions.assertEquals(0.6352779865264893, result.get("very good"), 0.000001);
+    Assertions.assertEquals(0.3003573715686798, result.get("good"), 0.000001);
+    Assertions.assertEquals(0.04995147883892059, result.get("neutral"), 0.000001);
+    Assertions.assertEquals(0.006593209225684404, result.get("bad"), 0.000001);
+    Assertions.assertEquals(0.007819971069693565, result.get("very bad"), 0.000001);
 
   }
 
@@ -197,11 +198,31 @@ public class DocumentCategorizerDLEval extends AbstactDLTest {
 
     final Map<Double, Set<String>> result = documentCategorizerDL.sortedScoreMap(new String[]{"I am happy"});
 
-    Assertions.assertEquals(result.get(0.6352779865264893).size(), 1);
-    Assertions.assertEquals(result.get(0.3003573715686798).size(), 1);
-    Assertions.assertEquals(result.get(0.04995147883892059).size(), 1);
-    Assertions.assertEquals(result.get(0.006593209225684404).size(), 1);
-    Assertions.assertEquals(result.get(0.007819971069693565).size(), 1);
+    Assertions.assertNotNull(result, "Result must not be NULL.");
+    Assertions.assertEquals(5, result.size());
+
+    final Iterator<Map.Entry<Double,Set<String>>> it = result.entrySet().iterator();
+
+    // we assume a sorted map here, so lets check in sorted order (lower values first).
+    Map.Entry<Double, Set<String>> e = it.next();
+    Assertions.assertEquals(0.006593209225684404, e.getKey(), 0.000001);
+    Assertions.assertEquals(e.getValue().size(), 1);
+
+    e = it.next();
+    Assertions.assertEquals(0.007819971069693565, e.getKey(), 0.000001);
+    Assertions.assertEquals(e.getValue().size(), 1);
+
+    e = it.next();
+    Assertions.assertEquals(0.04995147883892059, e.getKey(), 0.000001);
+    Assertions.assertEquals(e.getValue().size(), 1);
+
+    e = it.next();
+    Assertions.assertEquals(0.3003573715686798, e.getKey(), 0.000001);
+    Assertions.assertEquals(e.getValue().size(), 1);
+
+    e = it.next();
+    Assertions.assertEquals(0.6352779865264893, e.getKey(), 0.000001);
+    Assertions.assertEquals(e.getValue().size(), 1);
 
   }
 

--- a/opennlp-dl/src/test/java/opennlp/dl/namefinder/NameFinderDLEval.java
+++ b/opennlp-dl/src/test/java/opennlp/dl/namefinder/NameFinderDLEval.java
@@ -28,12 +28,12 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import opennlp.dl.AbstactDLTest;
+import opennlp.dl.AbstractDLTest;
 import opennlp.tools.sentdetect.SentenceDetector;
 import opennlp.tools.sentdetect.SentenceDetectorME;
 import opennlp.tools.util.Span;
 
-public class NameFinderDLEval extends AbstactDLTest {
+public class NameFinderDLEval extends AbstractDLTest {
 
   private static final Logger logger = LoggerFactory.getLogger(NameFinderDLEval.class);
   private final SentenceDetector sentenceDetector ;
@@ -64,7 +64,7 @@ public class NameFinderDLEval extends AbstactDLTest {
     Assertions.assertEquals(1, spans.length);
     Assertions.assertEquals(0, spans[0].getStart());
     Assertions.assertEquals(17, spans[0].getEnd());
-    Assertions.assertEquals(8.251646041870117, spans[0].getProb(), 0.000001);
+    Assertions.assertEquals(8.251646041870117, spans[0].getProb(), 0.00001);
     Assertions.assertEquals("George Washington", spans[0].getCoveredText(String.join(" ", tokens)));
 
   }


### PR DESCRIPTION
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:

- Fixes typo in abstract test class
- Adjusts delta value in NameFinderDLEval to pass in Jenkins CI environment
- Adjusts DocumentCategorizerDLEval#categorize: Remove unnecessary boxing
- Adjusts DocumentCategorizerDLEval#sortedScoreMap: Change test to not rely on floating values as map keys for testing the sorted order of the result.
