### PR TITLE
OPENNLP-1496 Migrate OpenNLP towards JDK 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [ 11, 17, 19 ]
+        java: [ 17, 19 ]
         experimental: [false]
 #        include:
 #          - java: 18-ea

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
       - id: extract_version
         name: Extract version
         shell: bash

--- a/opennlp-tools/pom.xml
+++ b/opennlp-tools/pom.xml
@@ -76,6 +76,14 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- JUnit5 extension used in CLITest to prevent System.exit(..) calls terminating test runs -->
+    <dependency>
+      <groupId>com.ginsberg</groupId>
+      <artifactId>junit5-system-exit</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/opennlp-tools/src/test/java/opennlp/tools/cmdline/CLITest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/cmdline/CLITest.java
@@ -17,105 +17,45 @@
 
 package opennlp.tools.cmdline;
 
-import java.security.Permission;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import com.ginsberg.junit.exit.ExpectSystemExitWithStatus;
 import org.junit.jupiter.api.Test;
 
 public class CLITest {
-
-  private static class ExitException extends SecurityException {
-
-    private static final long serialVersionUID = 6144359372794123631L;
-    
-    private final int status;
-
-    public ExitException(int status) {
-      this.status = status;
-    }
-
-    int status() {
-      return status;
-    }
-  }
-
-  /**
-   * A <code>SecurityManager</code> which prevents System.exit anything else is allowed.
-   */
-  private static class NoExitSecurityManager extends SecurityManager {
-
-    @Override
-    public void checkPermission(Permission perm) {
-    }
-
-    @Override
-    public void checkPermission(Permission perm, Object context) {
-    }
-
-    @Override
-    public void checkExit(int status) {
-      super.checkExit(status);
-
-      throw new ExitException(status);
-    }
-  }
-
-  private final SecurityManager originalSecurityManager = System.getSecurityManager();
-
-  @BeforeEach
-  void installNoExitSecurityManager() {
-    System.setSecurityManager(new NoExitSecurityManager());
-  }
 
   /**
    * Ensure the main method does not fail to print help message.
    */
   @Test
+  @ExpectSystemExitWithStatus(0)
   void testMainHelpMessage() {
-
-    try {
-      CLI.main(new String[] {});
-    } catch (ExitException e) {
-      Assertions.assertEquals(0, e.status());
-    }
+    CLI.main(new String[] {});
   }
 
   /**
    * Ensure the main method prints error and returns 1.
    */
   @Test
+  @ExpectSystemExitWithStatus(1)
   void testUnknownToolMessage() {
-    try {
-      CLI.main(new String[] {"unknown name"});
-    } catch (ExitException e) {
-      Assertions.assertEquals(1, e.status());
-    }
+    CLI.main(new String[] {"unknown name"});
   }
 
   /**
    * Ensure the tool checks the parameter and returns 1.
    */
   @Test
+  @ExpectSystemExitWithStatus(1)
   void testToolParameterMessage() {
-    try {
-      CLI.main(new String[] {"DoccatTrainer", "-param", "value"});
-    } catch (ExitException e) {
-      Assertions.assertEquals(1, e.status());
-    }
+    CLI.main(new String[] {"DoccatTrainer", "-param", "value"});
   }
 
   /**
    * Ensure the main method prints error and returns -1
    */
   @Test
+  @ExpectSystemExitWithStatus(-1)
   void testUnknownFileMessage() {
-    try {
-      CLI.main(new String[] {"Doccat", "unknown.model"});
-    } catch (ExitException e) {
-      Assertions.assertEquals(-1, e.status());
-    }
+    CLI.main(new String[] {"Doccat", "unknown.model"});
   }
 
 
@@ -123,20 +63,11 @@ public class CLITest {
    * Ensure all tools do not fail printing help message;
    */
   @Test
+  @ExpectSystemExitWithStatus(0)
   void testHelpMessageOfTools() {
-
     for (String toolName : CLI.getToolNames()) {
-      try {
-        CLI.main(new String[] {toolName, "help"});
-      } catch (ExitException e) {
-        Assertions.assertEquals(0, e.status());
-      }
+      CLI.main(new String[] {toolName, "help"});
     }
-  }
-
-  @AfterEach
-  void restoreSecurityManager() {
-    System.setSecurityManager(originalSecurityManager);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
 
 	<properties>
 		<!-- Build Properties -->
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<maven.version>3.3.9</maven.version>
 		<commons.io.version>2.11.0</commons.io.version>
 		<enforcer.plugin.version>3.3.0</enforcer.plugin.version>


### PR DESCRIPTION
Change
-
- switches Java version and compiler target '17'
- adapts CLITest to use lightweight JUnit5 extension and related annotations thereby dropping deprecated custom 'NoExitSecurityManager'
- adapts _github_ workflows config files

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
