### PR TITLE
OPENNLP-1512 Fix incorrect encoding used in Conll02NameSampleStream

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/AbstractConverterTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/AbstractConverterTool.java
@@ -113,7 +113,7 @@ public abstract class AbstractConverterTool<T,P> extends TypedCmdLineTool<T,P> {
       }
 
       try (ObjectStream<T> sampleStream = streamFactory.create(formatArgs)) {
-        Object sample;
+        T sample;
         while ((sample = sampleStream.read()) != null) {
           logger.info(sample.toString());
         }

--- a/opennlp-tools/src/main/java/opennlp/tools/formats/Conll02NameSampleStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/Conll02NameSampleStream.java
@@ -91,7 +91,20 @@ public class Conll02NameSampleStream implements ObjectStream<NameSample> {
    * @throws IOException Thrown if IO errors occurred.
    */
   public Conll02NameSampleStream(LANGUAGE lang, InputStreamFactory in, int types) throws IOException {
-    this (lang, new PlainTextByLineStream(in, StandardCharsets.UTF_8), types);
+    /*
+     * NOTE: KEEP this encoding here! The original CONLL 2002 data is provided as: ISO_8859_1.
+     */
+    this (lang, new PlainTextByLineStream(in, StandardCharsets.ISO_8859_1), types);
+    /*
+     * If related files are (incorrectly) interpreted as 'UTF-8' without prior conversion of
+     * the train/test files, then á, é, ñ,.. will be misinterpreted during processing and in
+     * resulting outcomes, e.g. produced via TokenNameFinderConverter.
+     *
+     * As a consequence, users of related tooling (OpenNLP Doc: CONLL 2002) will thus suffer
+     * from corrupted intermediate files, as an out-of the box experience.
+     * 
+     * Details see: https://issues.apache.org/jira/browse/OPENNLP-1512
+     */
   }
 
   static Span extract(int begin, int end, String beginTag) throws InvalidFormatException {


### PR DESCRIPTION
Notes
-
Verification conducted via a local SNAPSHOT distr build of the OpenNLP CLI tooling and the example in the OpenNLP doc, see: https://opennlp.apache.org/docs/2.3.0/manual/opennlp.html#tools.corpora.conll.2002

With this PR, the input `esp.train` is now read 'as is' (ISO_8859_1), with the resulting corpus txt file written correctly, that is, UTF-8. Result: No Spanish accents are corrupted or missing.

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
