### PR TITLE
OPENNLP-1519 Modify Tests in DictionaryAsSetCaseInsensitiveTest + DictionaryAsSetCaseSensitiveTest to handle any Iteration order

### DIFF
--- a/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseInsensitiveTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseInsensitiveTest.java
@@ -118,7 +118,8 @@ public class DictionaryAsSetCaseInsensitiveTest {
 
     Set<String> setB = dictB.asStringSet();
 
-    Assertions.assertEquals(setA, setB);
+    Assertions.assertEquals(setA.size(), setB.size());
+    Assertions.assertTrue(setA.containsAll(setB));
   }
 
   /**
@@ -139,7 +140,8 @@ public class DictionaryAsSetCaseInsensitiveTest {
 
     Set<String> setB = dictB.asStringSet();
 
-    Assertions.assertEquals(setA, setB);
+    Assertions.assertEquals(setA.size(), setB.size());
+    Assertions.assertTrue(setA.containsAll(setB));
   }
 
   /**

--- a/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseSensitiveTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/dictionary/DictionaryAsSetCaseSensitiveTest.java
@@ -118,7 +118,8 @@ public class DictionaryAsSetCaseSensitiveTest {
 
     Set<String> setB = dictB.asStringSet();
 
-    Assertions.assertEquals(setA, setB);
+    Assertions.assertEquals(setA.size(), setB.size());
+    Assertions.assertTrue(setA.containsAll(setB));
   }
 
   /**


### PR DESCRIPTION
This PR aims to fix three tests. 

Module: opennlp-tools
```
opennlp.tools.dictionary.DictionaryAsSetCaseInsensitiveTest.testEquals
opennlp.tools.dictionary.DictionaryAsSetCaseInsensitiveTest.testEqualsDifferentCase
opennlp.tools.dictionary.DictionaryAsSetCaseSensitiveTest.testEquals
```

**REASON AND FIX:**

The tests fail because in the `equals` method designed for comparing elements within a Set, the consideration extends to handle the ordering of elements as well.

https://github.com/apache/opennlp/blob/dab19af803e9139b57b972eb4e1af4c978d2ff3f/opennlp-tools/src/main/java/opennlp/tools/dictionary/Dictionary.java#L356

But the `entrySet` here is a HashSet which doesn't maintain a constant order as mentioned in the [Java_17_documentation](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/HashSet.html).

https://github.com/apache/opennlp/blob/dab19af803e9139b57b972eb4e1af4c978d2ff3f/opennlp-tools/src/main/java/opennlp/tools/dictionary/Dictionary.java#L95


The error message is as follows:

> org.opentest4j.AssertionFailedError: expected: <[1a, 1b]> but was: <[1b, 1a]>
at opennlp.tools.dictionary.DictionaryAsSetCaseInsensitiveTest.testEquals(DictionaryAsSetCaseInsensitiveTest.java:121)

> org.opentest4j.AssertionFailedError: expected: <[1a, 1b]> but was: <[1B, 1A]>
at opennlp.tools.dictionary.DictionaryAsSetCaseInsensitiveTest.testEqualsDifferentCase(DictionaryAsSetCaseInsensitiveTest.java:142)

> org.opentest4j.AssertionFailedError: expected: <[1a, 1b]> but was: <[1b, 1a]>
at opennlp.tools.dictionary.DictionaryAsSetCaseSensitiveTest.testEquals(DictionaryAsSetCaseSensitiveTest.java:121)


The solution involves modifying the assert statements to verify the presence of all elements without taking their order into account. 

**REPRODUCE:**

This was found by using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

The following command can be used to replicate the failures and validate the fix:

```
mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=opennlp.tools.dictionary.DictionaryAsSetCaseInsensitiveTest#testEquals
```

**ENVIRONMENT:**

> OS: Mac
> Version: Sonoma 14.0
> Java: openjdk version "17.0.9"
> Maven: Apache Maven 3.6.3


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?
