### PR TITLE
OPENNLP-1527 - OpenNLP CLI does not start on Windows

### DIFF
--- a/opennlp-distr/src/main/bin/opennlp.bat
+++ b/opennlp-distr/src/main/bin/opennlp.bat
@@ -45,9 +45,8 @@ IF "%OPENNLP_HOME%" == "" (
 	FOR %%A IN ("%OPENNLP_HOME%") DO SET OPENNLP_HOME=%%~sfA
 )
 
-REM #  Get the library JAR file name (JIRA OPENNLP-554)
-FOR %%A IN ("%OPENNLP_HOME%\lib\opennlp-tools-*.jar") DO SET JAR_FILE=%%A
+SET CLASSPATH="%OPENNLP_HOME%\lib\*"
 
-%JAVA_CMD% %HEAP% "-Dlog4j.configurationFile=%OPENNLP_HOME%\conf\log4j2.xml" -jar %JAR_FILE% %*
+%JAVA_CMD% %HEAP% "-Dlog4j.configurationFile=%OPENNLP_HOME%\conf\log4j2.xml" -cp %CLASSPATH% opennlp.tools.cmdline.CLI %*
 
 ENDLOCAL


### PR DESCRIPTION
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:

Adds the classpath to the windows bat file to ensure slf4j + log4j2 are available. User reports, that the updated bat files solves the issue, see https://stackoverflow.com/questions/77615264/why-does-opennlp-cli-output-slf4j-failed-to-load-class-org-slf4j-impl-staticl