### PR TITLE
OPENNLP-1537 Update Apache Parent POM to version 31

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,10 +26,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java: [ 17, 21 ]
         experimental: [false]
-#        include:
-#          - java: 18-ea
-#            os: ubuntu-latest
-#            experimental: true
+        include:
+          - java: 22-ea
+            os: ubuntu-latest
+            experimental: true
 
     steps:
     - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>29</version>
+		<version>31</version>
 		<relativePath />
 	</parent>
 
@@ -180,8 +180,8 @@
 		<opennlp.forkCount>1.0C</opennlp.forkCount>
 		<coveralls.maven.plugin>4.3.0</coveralls.maven.plugin>
 		<jacoco.maven.plugin>0.7.9</jacoco.maven.plugin>
-		<maven.surefire.plugin>2.22.2</maven.surefire.plugin>
-		<maven.failsafe.plugin>2.22.2</maven.failsafe.plugin>
+		<maven.surefire.plugin>3.2.2</maven.surefire.plugin>
+		<maven.failsafe.plugin>3.2.2</maven.failsafe.plugin>
 		<forbiddenapis.plugin>3.6</forbiddenapis.plugin>
 		<mockito.version>3.9.0</mockito.version>
 	</properties>
@@ -350,7 +350,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
 				<configuration>
 					<release>${java.version}</release>
 					<compilerArgument>-Xlint</compilerArgument>


### PR DESCRIPTION
Change
-
- updates to Apache parent pom version 31
- updates Maven surefire and failsafe plugins to be compliant to parent pom (-> 3.2.2)
- updates Maven compiler plugin (3.11.0), removing custom version string
- re-enables early-access JDK builds with version 22 to ensure build will hold with future JDKs

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
