### PR TITLE
OPENNLP-1542 - Fix NPE in Eval Tests

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/formats/ad/ADSentenceStream.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/formats/ad/ADSentenceStream.java
@@ -338,6 +338,7 @@ public class ADSentenceStream extends FilterObjectStream<String, ADSentenceStrea
           leaf.setLevel(level + 1);
           leaf.setSyntacticTag("");
           leaf.setMorphologicalTag("");
+          leaf.setFunctionalTag("");
           leaf.setLexeme(lexeme);
 
           return leaf;
@@ -349,6 +350,7 @@ public class ADSentenceStream extends FilterObjectStream<String, ADSentenceStrea
       leaf.setLevel(1);
       leaf.setSyntacticTag("");
       leaf.setMorphologicalTag("");
+      leaf.setFunctionalTag("");
       leaf.setLexeme(line);
 
       return leaf;

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/AbstractEvalTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/AbstractEvalTest.java
@@ -35,7 +35,6 @@ import opennlp.tools.ml.maxent.quasinewton.QNTrainer;
 import opennlp.tools.ml.naivebayes.NaiveBayesTrainer;
 import opennlp.tools.ml.perceptron.PerceptronTrainer;
 import opennlp.tools.util.ObjectStream;
-import opennlp.tools.util.StringUtil;
 import opennlp.tools.util.TrainingParameters;
 import opennlp.tools.util.model.ModelUtil;
 
@@ -101,7 +100,7 @@ public abstract class AbstractEvalTest {
 
   public static File getOpennlpDataDir() throws FileNotFoundException {
     final String dataDirectory = System.getProperty("OPENNLP_DATA_DIR");
-    if (StringUtil.isEmpty(dataDirectory)) {
+    if (dataDirectory == null || dataDirectory.isBlank()) {
       throw new IllegalArgumentException("The OPENNLP_DATA_DIR is not set.");
     }
     final File file = new File(System.getProperty("OPENNLP_DATA_DIR"));

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/ArvoresDeitadasEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/ArvoresDeitadasEval.java
@@ -188,26 +188,26 @@ public class ArvoresDeitadasEval extends AbstractEvalTest {
   @Test
   void evalPortugueseChunkerPerceptron() throws IOException {
     chunkerCrossEval(createPerceptronParams(),
-        0.9638122825015589d);
+        0.9631066789979492);
   }
 
   @Test
   void evalPortugueseChunkerGis() throws IOException {
     chunkerCrossEval(ModelUtil.createDefaultTrainingParameters(),
-        0.9573860781121228d);
+        0.9571790438663504);
   }
 
   @Test
   void evalPortugueseChunkerGisMultipleThreads() throws IOException {
     TrainingParameters params = ModelUtil.createDefaultTrainingParameters();
     params.put("Threads", 4);
-    chunkerCrossEval(params, 0.9573860781121228d);
+    chunkerCrossEval(params, 0.9571790438663504);
   }
 
   @Test
   void evalPortugueseChunkerQn() throws IOException {
     chunkerCrossEval(createMaxentQnParams(),
-        0.9651009811896799d);
+        0.9655574076677446);
   }
 
   @Test
@@ -216,7 +216,7 @@ public class ArvoresDeitadasEval extends AbstractEvalTest {
     params.put("Threads", 4);
 
     // NOTE: Should be the same as without multiple threads!!!
-    chunkerCrossEval(params, 0.9649180953528779d);
+    chunkerCrossEval(params, 0.9655858045209428);
   }
 
   @Test


### PR DESCRIPTION
### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:

Eval Run: https://ci-builds.apache.org/job/OpenNLP/job/eval-tests-configurable/17/

The current AD parser returns NULL tags in case they could not be parsed, for example: "=====P.vp" should be "=====P:vp" in the source data. 

The code in `ChunkSample` with `List.copyOf(....)` doesn't allow NULL values anymore leading to the NPE issue in the eval tests. 

This PR changes the related code to set an empty String instead of a NULL tag. I don't know, if `""`and `null` can be used as semantically equal here, but in any case it represents an unknown tag as a result from a failed parsing attempt. 

Eval accuracy will change a bit. See Slack thread for more details: https://the-asf.slack.com/archives/C03869UDYJG/p1704288164823829

