### PR TITLE
OPENNLP-1564 - Fix Evaluation Tests after POSFormat Change

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/postag/POSTagFormatMapper.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/postag/POSTagFormatMapper.java
@@ -206,4 +206,16 @@ public class POSTagFormatMapper {
       return POSTagFormat.UNKNOWN;
     }
   }
+
+  /**
+   * Guesses the {@link POSTagFormat} of a given {@link POSModel}
+   * @param posModel must not be {@code null}.
+   * @return the guessed {@link POSTagFormat}.
+   */
+  public static POSTagFormat guessFormat(POSModel posModel) {
+    Objects.requireNonNull(posModel, "POSModel must not be NULL.");
+    Objects.requireNonNull(posModel.getPosSequenceModel(), "POSSequenceModel must not be NULL.");
+    final POSTagFormatMapper mapper = new POSTagFormatMapper(posModel.getPosSequenceModel().getOutcomes());
+    return mapper.getGuessedFormat();
+  }
 }

--- a/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/POSTaggerNameFeatureGenerator.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/POSTaggerNameFeatureGenerator.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import opennlp.tools.postag.POSModel;
+import opennlp.tools.postag.POSTagFormatMapper;
 import opennlp.tools.postag.POSTagger;
 import opennlp.tools.postag.POSTaggerME;
 
@@ -50,8 +51,7 @@ public class POSTaggerNameFeatureGenerator implements AdaptiveFeatureGenerator {
    * @param aPosModel a POSTagger model.
    */
   public POSTaggerNameFeatureGenerator(POSModel aPosModel) {
-
-    this.posTagger = new POSTaggerME(aPosModel);
+    this.posTagger = new POSTaggerME(aPosModel, POSTagFormatMapper.guessFormat(aPosModel));
   }
 
 

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/ConllXPosTaggerEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/ConllXPosTaggerEval.java
@@ -31,6 +31,7 @@ import opennlp.tools.formats.ConllXPOSSampleStream;
 import opennlp.tools.postag.POSEvaluator;
 import opennlp.tools.postag.POSModel;
 import opennlp.tools.postag.POSSample;
+import opennlp.tools.postag.POSTagFormat;
 import opennlp.tools.postag.POSTaggerFactory;
 import opennlp.tools.postag.POSTaggerME;
 import opennlp.tools.util.MarkableFileInputStreamFactory;
@@ -73,7 +74,7 @@ public class ConllXPosTaggerEval extends AbstractEvalTest {
     ObjectStream<POSSample> samples = new ConllXPOSSampleStream(
         new MarkableFileInputStreamFactory(testData), StandardCharsets.UTF_8);
 
-    POSEvaluator evaluator = new POSEvaluator(new POSTaggerME(model));
+    POSEvaluator evaluator = new POSEvaluator(new POSTaggerME(model, POSTagFormat.PENN));
     evaluator.evaluate(samples);
 
     Assertions.assertEquals(expectedAccuracy, evaluator.getWordAccuracy(), 0.0001);

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/OntoNotes4PosTaggerEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/OntoNotes4PosTaggerEval.java
@@ -32,6 +32,7 @@ import opennlp.tools.formats.convert.ParseToPOSSampleStream;
 import opennlp.tools.formats.ontonotes.DocumentToLineStream;
 import opennlp.tools.formats.ontonotes.OntoNotesParseSampleStream;
 import opennlp.tools.postag.POSSample;
+import opennlp.tools.postag.POSTagFormat;
 import opennlp.tools.postag.POSTaggerCrossValidator;
 import opennlp.tools.postag.POSTaggerFactory;
 import opennlp.tools.util.ObjectStream;
@@ -59,7 +60,8 @@ public class OntoNotes4PosTaggerEval extends AbstractEvalTest {
   private void crossEval(TrainingParameters params, double expectedScore)
       throws IOException {
     try (ObjectStream<POSSample> samples = createPOSSampleStream()) {
-      POSTaggerCrossValidator cv = new POSTaggerCrossValidator("eng", params, new POSTaggerFactory());
+      POSTaggerCrossValidator cv = new POSTaggerCrossValidator("eng", params,
+          new POSTaggerFactory(), POSTagFormat.PENN);
       cv.evaluate(samples, 5);
 
       Assertions.assertEquals(expectedScore, cv.getWordAccuracy(), 0.0001d);

--- a/opennlp-tools/src/test/java/opennlp/tools/eval/SourceForgeModelEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/SourceForgeModelEval.java
@@ -44,6 +44,7 @@ import opennlp.tools.parser.ParserFactory;
 import opennlp.tools.parser.ParserModel;
 import opennlp.tools.postag.POSModel;
 import opennlp.tools.postag.POSSample;
+import opennlp.tools.postag.POSTagFormat;
 import opennlp.tools.postag.POSTagger;
 import opennlp.tools.postag.POSTaggerME;
 import opennlp.tools.sentdetect.SentenceDetector;
@@ -352,7 +353,7 @@ public class SourceForgeModelEval extends AbstractEvalTest {
 
     MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
 
-    POSTagger tagger = new POSTaggerME(model);
+    POSTagger tagger = new POSTaggerME(model, POSTagFormat.PENN);
 
     try (ObjectStream<LeipzigTestSample> lines = createLineWiseStream()) {
 


### PR DESCRIPTION
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:

Updates some missed `PENN` format cases in the evaluation test data. In addition, if `POSTaggerNameFeatureGenerator` is used for NameFinder (i.e. defined via XML), we only get a POSModel and need to guess the format of it before creating the `POSTagger`. Therefore, I updated the mapper with a static method for guessing this type based on a given POSModel. This might be useful for other cases as well.

Sadly, ASF Jenkins is currently broken, so we cannot trigger a manual run, see https://issues.apache.org/jira/browse/INFRA-25828