### PR TITLE
OPENNLP-1564 - Fix the last remaining eval test

### DIFF
--- a/opennlp-tools/src/test/java/opennlp/tools/eval/SourceForgeModelEval.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/eval/SourceForgeModelEval.java
@@ -324,7 +324,8 @@ public class SourceForgeModelEval extends AbstractEvalTest {
     MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
 
     POSTagger tagger = new POSTaggerME(new POSModel(
-        new File(getOpennlpDataDir(), "models-sf/en-pos-perceptron.bin")));
+        new File(getOpennlpDataDir(), "models-sf/en-pos-perceptron.bin")),
+        POSTagFormat.PENN);
 
     Chunker chunker = new ChunkerME(new ChunkerModel(
         new File(getOpennlpDataDir(), "models-sf/en-chunker.bin")));


### PR DESCRIPTION
This fixes 

```bash
[ERROR] opennlp.tools.eval.SourceForgeModelEval.evalChunkerModel -- Time elapsed: 1385 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <304922886851384639120257052245406261332> but was: <85416056838725341441074840387786758951>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at opennlp.tools.eval.SourceForgeModelEval.evalChunkerModel(SourceForgeModelEval.java:345)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   SourceForgeModelEval.evalChunkerModel:345 expected: <304922886851384639120257052245406261332> but was: <85416056838725341441074840387786758951>
[INFO] 
[ERROR] Tests run: 1040, Failures: 1, Errors: 0, Skipped: 3
```