### PR TITLE
OPENNLP-1590 Clear open TODO in GenericFactoryTest

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/GeneratorFactory.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/featuregen/GeneratorFactory.java
@@ -144,8 +144,8 @@ public class GeneratorFactory {
               (AbstractXmlFeatureGeneratorFactory) constructor.newInstance();
           factory.init(generatorElement, resourceManager);
           return factory.create();
-        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException
-                 | IllegalAccessException e) {
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException |
+                 InvalidFormatException | IllegalAccessException e) {
           throw new RuntimeException(e);
         }
       } catch (ClassNotFoundException e) {
@@ -351,8 +351,8 @@ public class GeneratorFactory {
           if (type.equals("generator")) {
             String key = "generator#" + generators.size();
             AdaptiveFeatureGenerator afg = buildGenerator(elem, resourceManager);
-            generators.add(afg);
             if (afg != null) {
+              generators.add(afg);
               args.put(key, afg);
             }
           } else {

--- a/opennlp-tools/src/test/resources/opennlp/tools/util/featuregen/DictionaryTest.xml
+++ b/opennlp-tools/src/test/resources/opennlp/tools/util/featuregen/DictionaryTest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
+
+<dictionary case_sensitive="false">
+  <entry>
+    <token>S.</token>
+  </entry>
+  <entry>
+    <token>z. B.</token>
+  </entry>
+  <entry>
+    <token>z.B.</token>
+  </entry>
+</dictionary>

--- a/opennlp-tools/src/test/resources/opennlp/tools/util/featuregen/TestDictionarySerializerMappingExtraction.xml
+++ b/opennlp-tools/src/test/resources/opennlp/tools/util/featuregen/TestDictionarySerializerMappingExtraction.xml
@@ -17,8 +17,8 @@
 	under the License.
 -->
 
-<featureGenerators name="test">
-  <generator class="opennlp.tools.util.featuregen.DictionaryFeatureGeneratorFactory">
-    <str name="dict">test.dictionary</str>
-  </generator>
+<featureGenerators cache="true" name="test">
+    <generator class="opennlp.tools.util.featuregen.DictionaryFeatureGeneratorFactory">
+      <str name="dict">opennlp/tools/util/featuregen/DictionaryTest.xml</str>
+    </generator>
 </featureGenerators>


### PR DESCRIPTION
Change
-
- adjusts `DictionaryFeatureGeneratorFactory` to handle situations without a ResourceManager instance at runtime
- fixes a missing Exception type in catch block of `GeneratorFactory#buildGenerator `which wasn't handled correctly
- clears TODO in GeneratorFactoryTest
- adds another test case to demonstrate that a descriptively declared dictionary is loaded for the creation of a `DictionaryFeatureGeneratorFactory`
- adds a related test resource

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
