### PR TITLE
OPENNLP-1607: SimpleClassPathModelFinder not returning list of matching paths

### DIFF
--- a/opennlp-tools-models/pom.xml
+++ b/opennlp-tools-models/pom.xml
@@ -91,13 +91,32 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin}</version>
                 <configuration>
-                    <argLine>-Xmx2048m -Dorg.slf4j.simpleLogger.defaultLogLevel=off --add-opens java.base/jdk.internal.loader=ALL-UNNAMED</argLine>
                     <forkCount>${opennlp.forkCount}</forkCount>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>with-reflection</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx2048m -Dorg.slf4j.simpleLogger.defaultLogLevel=off --add-opens java.base/jdk.internal.loader=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </execution>
+                    <!-- This phase is here to trigger a fallback to the classpath from the system properties, which cannot be hit, if add-opens is present. -->
+                    <execution>
+                        <id>no-reflection</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx2048m -Dorg.slf4j.simpleLogger.defaultLogLevel=off</argLine>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
-
         </plugins>
     </build>
 </project>

--- a/opennlp-tools-models/src/main/java/opennlp/tools/models/simple/SimpleClassPathModelFinder.java
+++ b/opennlp-tools-models/src/main/java/opennlp/tools/models/simple/SimpleClassPathModelFinder.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -192,11 +191,11 @@ public class SimpleClassPathModelFinder extends AbstractClassPathModelFinder imp
         return Arrays.asList(fromUcp);
       } else {
         final String cp = System.getProperty("java.class.path", "");
-        final Matcher matcher = CLASSPATH_SEPARATOR_PATTERN.matcher(cp);
+        final String[] matches = CLASSPATH_SEPARATOR_PATTERN.split(cp);
         final List<URL> jarUrls = new ArrayList<>();
-        while (matcher.find()) {
+        for (String classPath: matches) {
           try {
-            jarUrls.add(new URL(FILE_PREFIX, "", matcher.group()));
+            jarUrls.add(new URL(FILE_PREFIX, "", classPath));
           } catch (MalformedURLException ignored) {
             //if we cannot parse a URL from the system property, just ignore it...
             //we couldn't load it anyway

--- a/opennlp-tools-models/src/main/java/opennlp/tools/models/simple/SimpleClassPathModelFinder.java
+++ b/opennlp-tools-models/src/main/java/opennlp/tools/models/simple/SimpleClassPathModelFinder.java
@@ -63,7 +63,8 @@ public class SimpleClassPathModelFinder extends AbstractClassPathModelFinder imp
 
   private static final Logger logger = LoggerFactory.getLogger(SimpleClassPathModelFinder.class);
   private static final String FILE_PREFIX = "file";
-  private static final Pattern CLASSPATH_SEPARATOR_PATTERN = Pattern.compile("[;:]");
+  private static final Pattern CLASSPATH_SEPARATOR_PATTERN_WINDOWS = Pattern.compile(";");
+  private static final Pattern CLASSPATH_SEPARATOR_PATTERN_UNIX = Pattern.compile(":");
   // ; for Windows, : for Linux/OSX
 
   /**
@@ -190,20 +191,26 @@ public class SimpleClassPathModelFinder extends AbstractClassPathModelFinder imp
       if (fromUcp != null && fromUcp.length > 0) {
         return Arrays.asList(fromUcp);
       } else {
-        final String cp = System.getProperty("java.class.path", "");
-        final String[] matches = CLASSPATH_SEPARATOR_PATTERN.split(cp);
-        final List<URL> jarUrls = new ArrayList<>();
-        for (String classPath: matches) {
-          try {
-            jarUrls.add(new URL(FILE_PREFIX, "", classPath));
-          } catch (MalformedURLException ignored) {
-            //if we cannot parse a URL from the system property, just ignore it...
-            //we couldn't load it anyway
-          }
-        }
-        return jarUrls;
+        return getClassPathUrlsFromSystemProperty();
       }
     }
+  }
+
+  private List<URL> getClassPathUrlsFromSystemProperty() {
+    final String cp = System.getProperty("java.class.path", "");
+    final String[] matches = isWindows()
+            ? CLASSPATH_SEPARATOR_PATTERN_WINDOWS.split(cp)
+            : CLASSPATH_SEPARATOR_PATTERN_UNIX.split(cp);
+    final List<URL> jarUrls = new ArrayList<>();
+    for (String classPath: matches) {
+      try {
+        jarUrls.add(new URL(FILE_PREFIX, "", classPath));
+      } catch (MalformedURLException ignored) {
+        //if we cannot parse a URL from the system property, just ignore it...
+        //we couldn't load it anyway
+      }
+    }
+    return jarUrls;
   }
 
   /*


### PR DESCRIPTION
Updated SimpleClassPathModelFinder to return a list of paths instead of the delimiter

<img width="1055" alt="After" src="https://github.com/user-attachments/assets/7414bab6-80c0-4192-a405-cd2e85b5951c">


Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:

- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
