### PR TITLE
OPENNLP-1630 Move to Apache Parent 33

### DIFF
--- a/opennlp-tools-models/pom.xml
+++ b/opennlp-tools-models/pom.xml
@@ -89,7 +89,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin}</version>
                 <configuration>
                     <forkCount>${opennlp.forkCount}</forkCount>
                     <useSystemClassLoader>false</useSystemClassLoader>

--- a/opennlp-tools/pom.xml
+++ b/opennlp-tools/pom.xml
@@ -120,7 +120,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven.surefire.plugin}</version>
         <configuration>
           <argLine>-Xmx2048m -Dorg.slf4j.simpleLogger.defaultLogLevel=off -javaagent:${settings.localRepository}/com/ginsberg/junit5-system-exit/${junit5-system-exit.version}/junit5-system-exit-${junit5-system-exit.version}.jar</argLine>
           <forkCount>${opennlp.forkCount}</forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,8 @@
 	<properties>
 		<!-- Build Properties -->
 		<java.version>17</java.version>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.version>3.3.9</maven.version>
 		<enforcer.plugin.version>3.3.0</enforcer.plugin.version>
 		<jackson.version>2.18.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<connection>scm:git:https://github.com/apache/opennlp.git</connection>
 		<developerConnection>scm:git:git@github.com:apache/opennlp.git</developerConnection>
 		<url>https://github.com/apache/opennlp.git</url>
-		<tag>opennlp-2.3.1</tag>
+		<tag>opennlp-2.4.0</tag>
 	</scm>
 
 	<repositories>
@@ -60,7 +60,7 @@
 			<subscribe>users-subscribe@opennlp.apache.org</subscribe>
 			<unsubscribe>users-unsubscribe@opennlp.apache.org</unsubscribe>
 			<post>users@opennlp.apache.org</post>
-			<archive>http://mail-archives.apache.org/mod_mbox/opennlp-users/</archive>
+			<archive>https://mail-archives.apache.org/mod_mbox/opennlp-users/</archive>
 		</mailingList>
 
 		<mailingList>
@@ -68,21 +68,21 @@
 			<subscribe>dev-subscribe@opennlp.apache.org</subscribe>
 			<unsubscribe>dev-unsubscribe@opennlp.apache.org</unsubscribe>
 			<post>dev@opennlp.apache.org</post>
-			<archive>http://mail-archives.apache.org/mod_mbox/opennlp-dev/</archive>
+			<archive>https://mail-archives.apache.org/mod_mbox/opennlp-dev/</archive>
 		</mailingList>
 
 		<mailingList>
 			<name>Apache OpenNLP Commits</name>
 			<subscribe>commits-subscribe@opennlp.apache.org</subscribe>
 			<unsubscribe>commits-unsubscribe@opennlp.apache.org</unsubscribe>
-			<archive>http://mail-archives.apache.org/mod_mbox/opennlp-commits/</archive>
+			<archive>https://mail-archives.apache.org/mod_mbox/opennlp-commits/</archive>
 		</mailingList>
 
 		<mailingList>
 			<name>Apache OpenNLP Issues</name>
 			<subscribe>issues-subscribe@opennlp.apache.org</subscribe>
 			<unsubscribe>issues-unsubscribe@opennlp.apache.org</unsubscribe>
-			<archive>http://mail-archives.apache.org/mod_mbox/opennlp-issues/</archive>
+			<archive>https://mail-archives.apache.org/mod_mbox/opennlp-issues/</archive>
 		</mailingList>
 	</mailingLists>
 
@@ -168,13 +168,12 @@
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.version>3.3.9</maven.version>
-		<enforcer.plugin.version>3.3.0</enforcer.plugin.version>
 		<jackson.version>2.18.0</jackson.version>
 		<jersey.version>3.1.9</jersey.version>
 		<junit.version>5.11.2</junit.version>
+		<junit5-system-exit.version>2.0.0</junit5-system-exit.version>
 		<uimaj.version>3.5.0</uimaj.version>
 		<morfologik.version>2.1.9</morfologik.version>
-		<checkstyle.plugin.version>3.2.0</checkstyle.plugin.version>
 		<onnxruntime.version>1.19.2</onnxruntime.version>
 		<slf4j.version>2.0.16</slf4j.version>
 		<log4j2.version>2.23.1</log4j2.version>
@@ -182,11 +181,9 @@
 		<classgraph.version>4.8.176</classgraph.version>
 		<opennlp.models.version>1.0.1</opennlp.models.version>
 		<opennlp.forkCount>1.0C</opennlp.forkCount>
-		<junit5-system-exit.version>2.0.0</junit5-system-exit.version>
 		<coveralls.maven.plugin>4.3.0</coveralls.maven.plugin>
 		<jacoco.maven.plugin>0.8.12</jacoco.maven.plugin>
-		<maven.surefire.plugin>3.2.2</maven.surefire.plugin>
-		<maven.failsafe.plugin>3.2.2</maven.failsafe.plugin>
+		<maven.failsafe.plugin>3.5.1</maven.failsafe.plugin>
 		<forbiddenapis.plugin>3.8</forbiddenapis.plugin>
 	</properties>
 
@@ -219,7 +216,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>${checkstyle.plugin.version}</version>
 					<dependencies>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -290,7 +286,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>${maven.surefire.plugin}</version>
 					<configuration>
 						<argLine>-Xmx2048m -Dorg.slf4j.simpleLogger.defaultLogLevel=off</argLine>
 						<forkCount>${opennlp.forkCount}</forkCount>
@@ -418,7 +413,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>${enforcer.plugin.version}</version>
 				<executions>
 					<execution>
 						<id>enforce-java</id>
@@ -511,7 +505,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>${maven.surefire.plugin}</version>
 						<configuration>
 							<argLine>-Xmx4g</argLine>
 							<includes>
@@ -535,7 +528,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>${maven.surefire.plugin}</version>
 						<configuration>
 							<argLine>-Xmx20g</argLine>
 							<includes>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>31</version>
+		<version>33</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
Change
-
- aligns Apache parent project version to '33', see [changes](https://github.com/apache/maven-apache-parent/releases/tag/apache-33).
- drops outdated, custom-managed maven plugin versions (now via parent)
- updates maven.failsafe plugin to version 3.5.1

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
