### PR TITLE
Jira Auto Linking + Dependabot Config Update

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -12,6 +12,8 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+  autolink_jira:
+    - OPENNLP
   custom_subjects:
     new_pr: "[PR] {title} ({repository})"
     close_pr: "Re: [PR] {title} ({repository})"
@@ -38,3 +40,9 @@ github:
     - textprocessing
     - compling
 
+notifications:
+  commits:      commits@opennlp.apache.org
+  issues:       dev@opennlp.apache.org
+  pullrequests_status: dev@opennlp.apache.org
+  pullrequests_comment: dev@opennlp.apache.org
+  jira_options: link worklog

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "com.puppycrawl.tools:*"
-        update-types: [ "version-update:semver-major" ]
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
       - dependency-name: "io.github.classgraph:*"
         update-types: [ "version-update:semver-minor" ]
 


### PR DESCRIPTION
- Enable auto linking to Jira if commits starts with OPENNLP-XXXX
- Ignore patch and minor version updates of checkstype / puppycrawl.