### PR TITLE
OPENNLP-1670: Disable releases for apache.snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Apache snapshot repository should be enabled only for snapshots.

> `enabled`: `true` or `false` for whether this repository is enabled for the respective type (`releases` or `snapshots`). By default this is `true`.  ([source](https://maven.apache.org/pom.html#Repositories))

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< org.apache.opennlp:opennlp >---------------------
[INFO] Building Apache OpenNLP Reactor 2.5.2-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ opennlp ---
[INFO] Remote repositories used by project org.apache.opennlp:opennlp:pom:2.5.2-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * apache.snapshots (https://repository.apache.org/snapshots, default, releases+snapshots)
[INFO]    First introduced on root
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

https://issues.apache.org/jira/browse/OPENNLP-1670

## How was this patch tested?

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< org.apache.opennlp:opennlp >---------------------
[INFO] Building Apache OpenNLP Reactor 2.5.2-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ opennlp ---
[INFO] Remote repositories used by project org.apache.opennlp:opennlp:pom:2.5.2-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * apache.snapshots (https://repository.apache.org/snapshots, default, snapshots)
[INFO]    First introduced on root
```