### PR TITLE
OPENNLP-1447: Re-enable Cmdline Tool execution tests

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerTool.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/cmdline/tokenizer/TokenizerTrainerTool.java
@@ -21,6 +21,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import opennlp.tools.cmdline.AbstractTrainerTool;
 import opennlp.tools.cmdline.CmdLineUtil;
@@ -33,6 +34,7 @@ import opennlp.tools.ml.TrainerFactory.TrainerType;
 import opennlp.tools.tokenize.TokenSample;
 import opennlp.tools.tokenize.TokenizerFactory;
 import opennlp.tools.tokenize.TokenizerModel;
+import opennlp.tools.util.InvalidFormatException;
 import opennlp.tools.util.TrainingParameters;
 import opennlp.tools.util.model.ModelUtil;
 
@@ -53,9 +55,15 @@ public final class TokenizerTrainerTool
 
   static Dictionary loadDict(File f) throws IOException {
     Dictionary dict = null;
-    if (f != null) {
+    if (f != null && f.exists()) {
       CmdLineUtil.checkInputFile("abb dict", f);
-      dict = new Dictionary(new BufferedInputStream(new FileInputStream(f)));
+      try (InputStream in = new BufferedInputStream(new FileInputStream(f))) {
+        if (in.available() == 0) {
+          throw new InvalidFormatException("Encountered an empty dictionary file?!");
+        } else {
+          dict = new Dictionary(in);
+        }
+      }
     }
     return dict;
   }

--- a/opennlp-tools/src/test/resources/logback-test.xml
+++ b/opennlp-tools/src/test/resources/logback-test.xml
@@ -23,11 +23,15 @@
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+            <pattern>%date{HH:mm:ss.SSS} [%thread] %-4level %class{36}.%method:%line - %msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="opennlp" level="off"/>
+
+    <logger name="opennlp.tools.cmdline.namefind" level="off"/>
+    
+    <logger name="opennlp.tools.cmdline.CmdLineUtil" level="off"/>
 
     <root level="off">
         <appender-ref ref="consoleAppender" />


### PR DESCRIPTION
Change
-
- removes `@Disabled` from multiple cmdline execution tests
- adjusts `TokenizerTrainerTool` to handle existing yet "empty" abb-dict files better

Tasks
-
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
