### PR TITLE
OPENNLP-1687: Remove quotes around $HEAP in opennlp tools shell script

### DIFF
--- a/opennlp-distr/src/main/bin/opennlp
+++ b/opennlp-distr/src/main/bin/opennlp
@@ -58,4 +58,4 @@ if [ -n "$JAVA_HEAP" ] ; then
   HEAP="-Xmx$JAVA_HEAP"
 fi
 
-$JAVACMD "$HEAP" -Dlog4j.configurationFile="$OPENNLP_HOME/conf/log4j2.xml" -cp "$CLASSPATH" opennlp.tools.cmdline.CLI "$@"
+$JAVACMD $HEAP -Dlog4j.configurationFile="$OPENNLP_HOME/conf/log4j2.xml" -cp "$CLASSPATH" opennlp.tools.cmdline.CLI "$@"


### PR DESCRIPTION


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.


----

Previously, $HEAP was wrapped in quotes when passed to java, causing an empty or incorrect argument to be parsed, which could trigger a “Could not find or load main class” error (e.g., in Homebrew environments). By removing the quotes, $HEAP is now passed correctly, ensuring Java recognizes the classpath and preventing the ClassNotFoundException. This also allows multiple or custom JVM arguments (e.g., -Xmx512m -Xms256m) to be supplied through $JAVA_HEAP if desired.

relates to https://github.com/Homebrew/homebrew-core/pull/202547