### PR TITLE
Enable dependabot for non default branches (2.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       interval: weekly
       time: '04:00'
     open-pull-requests-limit: 10
+    target-branch: "main"
     ignore:
       - dependency-name: "com.puppycrawl.tools:*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
@@ -32,3 +33,27 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "main"
+
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: '04:00'
+    open-pull-requests-limit: 10
+    target-branch: "opennlp-2.x"
+    commit-message:
+      prefix: "[2.x]"
+    ignore:
+      - dependency-name: "com.puppycrawl.tools:*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "io.github.classgraph:*"
+        update-types: [ "version-update:semver-minor" ]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "opennlp-2.x"
+    commit-message:
+      prefix: "[2.x]"


### PR DESCRIPTION
This PR extends the Dependabot configuration to also run on the opennlp-2.x branch.
By default, Dependabot only targets the default branch (main). Adding support for opennlp-2.x ensures that dependency updates are applied directly on that branch as well.

This will be Keeping dependencies up to date consistently across branches avoiding manual cherry-picking or backporting of version bumps. 

See option referendes: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference