### PR TITLE
OPENNLP-1826 : Prevent OOM during Array Allocation

### DIFF
--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/en/HeadRules.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/en/HeadRules.java
@@ -48,6 +48,12 @@ import opennlp.tools.util.model.SerializableArtifact;
  */
 public class HeadRules implements opennlp.tools.parser.HeadRules, GapLabeler, SerializableArtifact {
 
+  // POS tagsets are fixed by linguistic convention (Penn Treebank: ~45 tags).
+  // No single head rule will ever list more than a small fraction of the tagset.
+  // 1000 gives 20x headroom over the real-world maximum and is not configurable
+  // because tag counts are a linguistics constraint, not a deployment parameter.
+  private static final int MAX_TAGS_PER_RULE = 1_000;
+
   public static class HeadRulesSerializer implements ArtifactSerializer<HeadRules> {
 
     public HeadRules create(InputStream in) throws IOException {
@@ -196,8 +202,14 @@ public class HeadRules implements opennlp.tools.parser.HeadRules, GapLabeler, Se
       String num = st.nextToken();
       String type = st.nextToken();
       String dir = st.nextToken();
-      int numTags = Integer.parseInt(num) - 2;
-      if (numTags < 0 || numTags > 1_000) {
+      int rawCount;
+      try {
+        rawCount = Integer.parseInt(num);
+      } catch (NumberFormatException e) {
+        throw new IOException("Invalid tag count in head rules: " + num, e);
+      }
+      int numTags = rawCount - 2;
+      if (numTags < 0 || numTags > MAX_TAGS_PER_RULE) {
         throw new IOException("Invalid tag count in head rules: " + num);
       }
       String[] tags = new String[numTags];

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/en/HeadRules.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/en/HeadRules.java
@@ -196,7 +196,11 @@ public class HeadRules implements opennlp.tools.parser.HeadRules, GapLabeler, Se
       String num = st.nextToken();
       String type = st.nextToken();
       String dir = st.nextToken();
-      String[] tags = new String[Integer.parseInt(num) - 2];
+      int numTags = Integer.parseInt(num) - 2;
+      if (numTags < 0 || numTags > 1_000) {
+        throw new IOException("Invalid tag count in head rules: " + num);
+      }
+      String[] tags = new String[numTags];
       int ti = 0;
       while (st.hasMoreTokens()) {
         tags[ti] = st.nextToken();

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/es/AncoraSpanishHeadRules.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/es/AncoraSpanishHeadRules.java
@@ -62,6 +62,12 @@ import opennlp.tools.util.model.SerializableArtifact;
  */
 public class AncoraSpanishHeadRules implements HeadRules, GapLabeler, SerializableArtifact {
 
+  // POS tagsets are fixed by linguistic convention (Penn Treebank: ~45 tags).
+  // No single head rule will ever list more than a small fraction of the tagset.
+  // 1000 gives 20x headroom over the real-world maximum and is not configurable
+  // because tag counts are a linguistics constraint, not a deployment parameter.
+  private static final int MAX_TAGS_PER_RULE = 1_000;
+
   public static class HeadRulesSerializer implements ArtifactSerializer<AncoraSpanishHeadRules> {
 
     public AncoraSpanishHeadRules create(InputStream in) throws IOException {
@@ -212,8 +218,14 @@ public class AncoraSpanishHeadRules implements HeadRules, GapLabeler, Serializab
       String num = st.nextToken();
       String type = st.nextToken();
       String dir = st.nextToken();
-      int numTags = Integer.parseInt(num) - 2;
-      if (numTags < 0 || numTags > 1_000) {
+      int rawCount;
+      try {
+        rawCount = Integer.parseInt(num);
+      } catch (NumberFormatException e) {
+        throw new IOException("Invalid tag count in head rules: " + num, e);
+      }
+      int numTags = rawCount - 2;
+      if (numTags < 0 || numTags > MAX_TAGS_PER_RULE) {
         throw new IOException("Invalid tag count in head rules: " + num);
       }
       String[] tags = new String[numTags];

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/es/AncoraSpanishHeadRules.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/parser/lang/es/AncoraSpanishHeadRules.java
@@ -212,7 +212,11 @@ public class AncoraSpanishHeadRules implements HeadRules, GapLabeler, Serializab
       String num = st.nextToken();
       String type = st.nextToken();
       String dir = st.nextToken();
-      String[] tags = new String[Integer.parseInt(num) - 2];
+      int numTags = Integer.parseInt(num) - 2;
+      if (numTags < 0 || numTags > 1_000) {
+        throw new IOException("Invalid tag count in head rules: " + num);
+      }
+      String[] tags = new String[numTags];
       int ti = 0;
       while (st.hasMoreTokens()) {
         tags[ti] = st.nextToken();

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/parser/lang/en/HeadRulesTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/parser/lang/en/HeadRulesTest.java
@@ -23,12 +23,44 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class HeadRulesTest {
+
+  /**
+   * Positive: a well-formed head rules line with a small tag count loads without error.
+   */
+  @Test
+  void testValidTagCountLoads() throws IOException {
+    // "5 NP 1 NN NNS" — num=5, tags=3 (5-2=3)
+    String rules = "5 NP 1 NN NNS NNP\n";
+    Assertions.assertDoesNotThrow(() -> new HeadRules(new StringReader(rules)));
+  }
+
+  /**
+   * Negative: a head rules line with a huge tag count must throw IOException,
+   * not attempt to allocate Integer.MAX_VALUE bytes.
+   */
+  @Test
+  void testOversizedTagCountThrows() {
+    String rules = "2147483647 NP 1\n";
+    Assertions.assertThrows(IOException.class,
+        () -> new HeadRules(new StringReader(rules)));
+  }
+
+  /**
+   * Negative: a tag count that would produce a negative array size must throw IOException.
+   */
+  @Test
+  void testNegativeTagCountThrows() {
+    String rules = "1 NP 1\n";  // 1 - 2 = -1
+    Assertions.assertThrows(IOException.class,
+        () -> new HeadRules(new StringReader(rules)));
+  }
 
   @Test
   void testSerialization() throws IOException {

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/parser/lang/en/HeadRulesTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/parser/lang/en/HeadRulesTest.java
@@ -62,6 +62,27 @@ public class HeadRulesTest {
         () -> new HeadRules(new StringReader(rules)));
   }
 
+  /**
+   * Boundary: value just above MAX_TAGS_PER_RULE (1003 → numTags = 1001) must throw IOException.
+   */
+  @Test
+  void testJustAboveLimitThrows() {
+    // 1003 declared; 1003 - 2 = 1001 tags, which exceeds MAX_TAGS_PER_RULE (1000)
+    String rules = "1003 NP 1\n";
+    Assertions.assertThrows(IOException.class,
+        () -> new HeadRules(new StringReader(rules)));
+  }
+
+  /**
+   * Negative: non-numeric token count must throw IOException, not NumberFormatException.
+   */
+  @Test
+  void testNonNumericTagCountThrows() {
+    String rules = "NaN NP 1\n";
+    Assertions.assertThrows(IOException.class,
+        () -> new HeadRules(new StringReader(rules)));
+  }
+
   @Test
   void testSerialization() throws IOException {
     try (InputStream headRulesIn =


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  - `HeadRules` (English) and `AncoraSpanishHeadRules` (Spanish) parsed the                                                                                                                                                                                                                 
    tag count field from head rules files with `Integer.parseInt()` and used                                                                                                                                                                                                                
    the result directly as an array size with no bounds check. A crafted model                                                                                                                                                                                                              
    file with a count of `Integer.MAX_VALUE` would trigger an immediate                                                                                                                                                                                                                     
    `OutOfMemoryError` during parser model loading.                                                                                                                                                                                                                                         
  - Added a bounds check in `readHeadRules()` in both classes: values outside                                                                                                                                                                                                               
    `[0, 1000]` throw `IOException` before any allocation. 
    
    Since this is constrained by the size of the POS tagset being used this is already a safe margin and a configurable override may not have benefit.