### PR TITLE
[1.x] OPENNLP-1819: Align DictionaryEntryPersistor XML parsing with XmlUtil helper

### DIFF
--- a/opennlp-tools/src/main/java/opennlp/tools/dictionary/serializer/DictionaryEntryPersistor.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/dictionary/serializer/DictionaryEntryPersistor.java
@@ -38,10 +38,10 @@ import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 import opennlp.tools.util.InvalidFormatException;
 import opennlp.tools.util.StringList;
+import opennlp.tools.util.XmlUtil;
 import opennlp.tools.util.model.UncloseableInputStream;
 
 /**
@@ -217,7 +217,7 @@ public class DictionaryEntryPersistor {
 
     XMLReader xmlReader;
     try {
-      xmlReader = XMLReaderFactory.createXMLReader();
+      xmlReader = XmlUtil.createSaxParser().getXMLReader();
       xmlReader.setContentHandler(profileContentHandler);
       xmlReader.parse(new InputSource(new UncloseableInputStream(in)));
     }

--- a/opennlp-tools/src/main/java/opennlp/tools/util/XmlUtil.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/util/XmlUtil.java
@@ -29,14 +29,34 @@ import org.xml.sax.SAXException;
 public class XmlUtil {
 
   /**
-   * Create a new DocumentBuilder which processes XML securely.
+   * Create a new {@link DocumentBuilder} which processes XML securely.
    *
-   * @return a DocumentBuilder
+   * @return A valid {@link DocumentBuilder} instance.
+   * @throws IllegalStateException Thrown if errors occurred creating the builder.
    */
   public static DocumentBuilder createDocumentBuilder() {
+    final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
     try {
-      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
       documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    } catch (ParserConfigurationException e) {
+      // XMLConstants.FEATURE_SECURE_PROCESSING is not supported on Android.
+      // See DocumentBuilderFactory#setFeature
+      System.err.println("Failed to enable XMLConstants.FEATURE_SECURE_PROCESSING, " +
+          "it's unsupported on this platform: " + e.getMessage());
+    }
+    try {
+      documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      documentBuilderFactory.setFeature(
+          "http://apache.org/xml/features/disallow-doctype-decl", true);
+      documentBuilderFactory.setFeature(
+          "http://xml.org/sax/features/external-general-entities", false);
+      documentBuilderFactory.setFeature(
+          "http://xml.org/sax/features/external-parameter-entities", false);
+      documentBuilderFactory.setFeature(
+          "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      documentBuilderFactory.setXIncludeAware(false);
+      documentBuilderFactory.setExpandEntityReferences(false);
       return documentBuilderFactory.newDocumentBuilder();
     } catch (ParserConfigurationException e) {
       throw new IllegalStateException(e);
@@ -44,15 +64,32 @@ public class XmlUtil {
   }
 
   /**
-   * Create a new SAXParser which processes XML securely.
+   * Create a new {@link SAXParser} which processes XML securely.
    *
-   * @return a SAXParser
+   * @return A valid {@link SAXParser} instance.
+   * @throws IllegalStateException Thrown if errors occurred creating the parser.
    */
   public static SAXParser createSaxParser() {
-    SAXParserFactory spf = SAXParserFactory.newInstance();
+    final SAXParserFactory spf = SAXParserFactory.newInstance();
+    spf.setNamespaceAware(true);
+    spf.setXIncludeAware(false);
     try {
       spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      return spf.newSAXParser();
+    } catch (ParserConfigurationException | SAXException e) {
+      // XMLConstants.FEATURE_SECURE_PROCESSING is not supported on Android.
+      // See SAXParserFactory#setFeature
+      System.err.println("Failed to enable XMLConstants.FEATURE_SECURE_PROCESSING, " +
+          "it's unsupported on this platform: " + e.getMessage());
+    }
+    try {
+      spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      final SAXParser parser = spf.newSAXParser();
+      parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      return parser;
     } catch (ParserConfigurationException | SAXException e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
Backport of #1020 to `opennlp-1.x`.

## Problem
`DictionaryEntryPersistor.create()` built its `XMLReader` via the deprecated, insecure `XMLReaderFactory.createXMLReader()`, bypassing OpenNLP's secure XML parser configuration (XXE exposure).

## Fix
- Route dictionary parsing through `XmlUtil.createSaxParser().getXMLReader()`.
- Harden `XmlUtil` (both `createDocumentBuilder` and `createSaxParser`): disable external DTD/schema access and external general/parameter entities, disallow DOCTYPE declarations, disable XInclude and entity-reference expansion. `FEATURE_SECURE_PROCESSING` is attempted in a guarded block so platforms lacking it (e.g. Android) still work. Namespace awareness is set on the factory (replacing the old per-reader feature flag).

## 1.x adaptations vs. the 2.x change
- `opennlp-tools` on this branch has no slf4j; the unsupported-feature warning is emitted via `System.err`, the branch's logging idiom.

First of two stacked XmlUtil ports; the follow-up is OPENNLP-1835 (tolerate unsupported XML parser security options).

Tests: all `*Dictionary*` serializer tests pass on Temurin JDK 8.