### PR TITLE
OPENNLP-1843: Override surefire skip so eval tests run again

### DIFF
--- a/opennlp-eval-tests/pom.xml
+++ b/opennlp-eval-tests/pom.xml
@@ -138,6 +138,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <skip>false</skip>
               <argLine>-Xmx4g</argLine>
               <forkCount>${opennlp.forkCount}</forkCount>
               <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
@@ -158,6 +159,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <skip>false</skip>
               <argLine>-Xmx20g</argLine>
               <forkCount>1</forkCount>
               <includes>


### PR DESCRIPTION
## What

Adds `<skip>false</skip>` to the surefire configuration of the `eval-tests` and `high-memory-tests` profiles in `opennlp-eval-tests`.

## Why

See [OPENNLP-1843](https://issues.apache.org/jira/browse/OPENNLP-1843). The module's base build sets surefire `skip=true` and the profiles never override it, so Maven's config merge leaves the skip in effect: the module compiles its eval sources and executes zero tests, even with `-Peval-tests`. Every eval class in the module is affected. Visible in eval-tests-configurable build #48, where the module section shows only compilation (~1.2s) and no `*Eval` class appears in the console log.

## Validation

Reproduced locally (`mvn -pl opennlp-eval-tests -Peval-tests test` completes in ~1.5s running nothing). With the fix, the evals execute and fail loudly when `OPENNLP_DATA_DIR` is unset instead of being skipped silently.