### PR TITLE
OPENNLP-1851: Fix DocumentCategorizerDLEval.categorizeFailsLoudlyOnFa…

### DIFF
--- a/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/AbstractDL.java
+++ b/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/AbstractDL.java
@@ -424,7 +424,7 @@ public abstract class AbstractDL implements AutoCloseable {
    */
   @Override
   public void close() throws OrtException {
-    if (closed.compareAndSet(false, true)) {
+    if (closed.compareAndSet(false, true) && session != null) {
       session.close();
     }
   }

--- a/opennlp-eval-tests/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
+++ b/opennlp-eval-tests/src/test/java/opennlp/dl/doccat/DocumentCategorizerDLEval.java
@@ -161,17 +161,23 @@ public class DocumentCategorizerDLEval extends AbstractEvalTest {
     try (final DocumentCategorizerDL documentCategorizerDL =
              categorizerWithoutSession()) {
 
-      // Empty input drives categorize() down its failure path (strings[0] throws) before any
-      // inference; it must fail loudly rather than return an invalid all-zero distribution.
-      final IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () ->
+      // Malformed input is rejected up front with IllegalArgumentException.
+      Assertions.assertThrows(IllegalArgumentException.class, () ->
+          documentCategorizerDL.categorize(null));
+      Assertions.assertThrows(IllegalArgumentException.class, () ->
           documentCategorizerDL.categorize(new String[0]));
+
+      // Valid input with no session must fail loudly rather than return an invalid all-zero
+      // distribution.
+      final IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, () ->
+          documentCategorizerDL.categorize(new String[] {"hello world"}));
       Assertions.assertTrue(e.getMessage().contains("document classification inference"));
 
       // The dependent API must not mask that inference failure with all-zero scores.
       Assertions.assertThrows(IllegalStateException.class, () ->
-          documentCategorizerDL.scoreMap(new String[0]));
+          documentCategorizerDL.scoreMap(new String[] {"hello world"}));
       Assertions.assertThrows(IllegalStateException.class, () ->
-          documentCategorizerDL.sortedScoreMap(new String[0]));
+          documentCategorizerDL.sortedScoreMap(new String[] {"hello world"}));
     }
 
   }


### PR DESCRIPTION
…ilure

Align eval test with OPENNLP-1845 input validation and guard AbstractDL.close() when session is null.

Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
