### PR TITLE
OPENNLP-1858: [2.x] Add ASF allowlist-check workflow for GitHub Actions

### DIFF
--- a/.github/workflows/allowlist-check.yml
+++ b/.github/workflows/allowlist-check.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that every GitHub Action referenced via `uses:` in .github/**/*.yml is
+# on the ASF approved-actions allowlist, see:
+# https://github.com/apache/infrastructure-actions/tree/main/allowlist-check
+# This guards against disallowed Actions sneaking in, e.g. via Dependabot
+# github-actions update PRs. It is wired up as a required status check in .asf.yaml.
+name: ASF Allowlist Check
+
+on:
+  workflow_dispatch:
+  # No paths filter on purpose: as a required status check this job must report a
+  # status on every PR, otherwise PRs that don't touch .github/** would be blocked.
+  pull_request:
+  push:
+    branches:
+      - main
+      - opennlp-2.x
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@main


### PR DESCRIPTION
Backport of the `ASF Allowlist Check` workflow to the `opennlp-2.x` branch.

> [!NOTE]
> Branch-protection enforcement (`required_status_checks`) is configured in
> `.asf.yaml` on the default branch (`main`, see the companion PR), since ASF infra
> reads branch protection from the default branch only. This PR only adds the
> workflow and removes the `paths:` filter so the check runs on every PR.

## Change

Adds a new `ASF Allowlist Check` workflow (`.github/workflows/allowlist-check.yml`)
that runs [`apache/infrastructure-actions/allowlist-check`](https://github.com/apache/infrastructure-actions/tree/main/allowlist-check),
and makes it a required status check via `.asf.yaml`.

The action scans the `uses:` references in `.github/**/*.yml` against ASF's
approved-actions allowlist and fails if a disallowed GitHub Action is referenced.

## Why

Dependabot's `github-actions` ecosystem opens PRs that modify our workflow files.
This check ensures such updates (and any other workflow change) cannot introduce a
GitHub Action that is not on the ASF allowlist before it gets merged.

## Enforcement

`.asf.yaml` marks `asf-allowlist-check` as a `required_status_checks` context for
both `main` and `opennlp-2.x`. ASF infra applies branch protection from the default
branch only, so this single `.asf.yaml` (on `main`) covers both branches.

Because a required check that never runs would block unrelated PRs forever, the
`pull_request` trigger no longer has a `paths:` filter — the job now runs on every
PR and always reports a status. It is a lightweight Python scan of `.github/**/*.yml`,
so running it on all PRs is harmless.

## Triggers

- `pull_request` (every PR — required to satisfy the required status check)
- `push` to `main` / `opennlp-2.x` touching `.github/**`
- manual `workflow_dispatch`

Runs with `contents: read` only; `actions/checkout` is SHA-pinned with
`persist-credentials: false`. The ASF action is referenced at `@main` per ASF infra
guidance (it is itself allowlisted, so it won't trip its own check).
