### PR TITLE
OPENNLP-1871: Add the stopword-list BSD section to the binary distribution LICENSE

### DIFF
--- a/opennlp-distr/src/main/readme/LICENSE
+++ b/opennlp-distr/src/main/readme/LICENSE
@@ -230,6 +230,41 @@ The following license applies to the Snowball stemmers:
         OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF 
 
 
+The following license applies to the bundled stopword lists in
+opennlp-core/opennlp-runtime/src/main/resources/opennlp/tools/stopword.
+These lists are derived from Apache Lucene, which redistributes them from
+the Snowball project; the Bulgarian list (bg.txt) was created by Jacques
+Savoy (http://members.unine.ch/jacques.savoy/clef/index.html). They are
+distributed under the BSD license:
+
+	Copyright (c) 2001, Dr Martin Porter
+	Copyright (c) 2002, Richard Boulton
+	Copyright (c) Jacques Savoy
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are met:
+
+	    * Redistributions of source code must retain the above copyright notice,
+	    * this list of conditions and the following disclaimer.
+	    * Redistributions in binary form must reproduce the above copyright
+	    * notice, this list of conditions and the following disclaimer in the
+	    * documentation and/or other materials provided with the distribution.
+	    * Neither the name of the copyright holders nor the names of its contributors
+	    * may be used to endorse or promote products derived from this software
+	    * without specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+	AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+	FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+	DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+	CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+	OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 The CDDL 1.1 license applies to jersey and some of its dependencies:
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)Version 1.1


### PR DESCRIPTION
The root LICENSE carries a BSD section for the stopword lists bundled under `opennlp/tools/stopword` (derived from Apache Lucene, which redistributes them from the Snowball project; the Bulgarian list by Jacques Savoy). The hand-maintained binary distribution LICENSE (`opennlp-distr/src/main/readme/LICENSE`) did not carry it, although the binary distribution ships the lists inside the opennlp-runtime jar. The existing Snowball stemmers section covers the stemmers, not the lists, so the new section sits next to it.

The distr NOTICE is regenerated from NOTICE.template and needs no change.

Noticed during the licensing pass discussed on #1108; filed separately as requested there.
