### PR TITLE
OPENNLP-1878: Non-breaking performance follow-up for the 1850 normalization and tokenization hot paths

### DIFF
--- a/opennlp-api/src/main/java/opennlp/tools/util/normalizer/Alignment.java
+++ b/opennlp-api/src/main/java/opennlp/tools/util/normalizer/Alignment.java
@@ -207,11 +207,37 @@ public final class Alignment {
   public static final class Builder {
 
     private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    private static final int DEFAULT_CAPACITY = 16;
 
-    private int[] starts = new int[16];
-    private int[] ends = new int[16];
+    private int[] starts;
+    private int[] ends;
     private int count;
     private int originalCursor;
+
+    /** Creates a builder with a small default capacity. */
+    public Builder() {
+      this(DEFAULT_CAPACITY);
+    }
+
+    /**
+     * Creates a builder pre-sized for a normalized text of about {@code expectedLength}
+     * characters, so recording the edits of a typical pass (one entry per normalized character)
+     * does not regrow the backing arrays. The value is a sizing hint only; it does not limit how
+     * many edits can be recorded.
+     *
+     * @param expectedLength The expected normalized length, typically the length of the text
+     *     being normalized; must not be negative.
+     * @throws IllegalArgumentException Thrown if {@code expectedLength} is negative.
+     */
+    public Builder(int expectedLength) {
+      if (expectedLength < 0) {
+        throw new IllegalArgumentException(
+            "The expectedLength must not be negative: " + expectedLength);
+      }
+      final int capacity = Math.max(DEFAULT_CAPACITY, expectedLength);
+      starts = new int[capacity];
+      ends = new int[capacity];
+    }
 
     /**
      * Records {@code charCount} characters copied through unchanged (a one to one run).

--- a/opennlp-api/src/main/java/opennlp/tools/util/normalizer/CharClass.java
+++ b/opennlp-api/src/main/java/opennlp/tools/util/normalizer/CharClass.java
@@ -420,7 +420,7 @@ public final class CharClass {
   public AlignedText normalizeAligned(CharSequence text) {
     requireNonNullArg(text, "text");
     final StringBuilder out = new StringBuilder(text.length());
-    final Alignment.Builder alignment = new Alignment.Builder();
+    final Alignment.Builder alignment = new Alignment.Builder(text.length());
     final int length = text.length();
     int i = 0;
     while (i < length) {
@@ -457,7 +457,7 @@ public final class CharClass {
   public AlignedText collapseAligned(CharSequence text) {
     requireNonNullArg(text, "text");
     final StringBuilder out = new StringBuilder(text.length());
-    final Alignment.Builder alignment = new Alignment.Builder();
+    final Alignment.Builder alignment = new Alignment.Builder(text.length());
     final int length = text.length();
     int i = 0;
     while (i < length) {
@@ -502,7 +502,7 @@ public final class CharClass {
     requireNonNullArg(keep, "keep");
     requireValidCodePoint(keepReplacement);
     final StringBuilder out = new StringBuilder(text.length());
-    final Alignment.Builder alignment = new Alignment.Builder();
+    final Alignment.Builder alignment = new Alignment.Builder(text.length());
     final int length = text.length();
     int i = 0;
     while (i < length) {
@@ -595,7 +595,7 @@ public final class CharClass {
       }
       end -= charCount;
     }
-    final Alignment.Builder alignment = new Alignment.Builder();
+    final Alignment.Builder alignment = new Alignment.Builder(text.length());
     if (start > 0) {
       alignment.replace(start, 0);
     }
@@ -617,7 +617,7 @@ public final class CharClass {
   public AlignedText removeAllAligned(CharSequence text) {
     requireNonNullArg(text, "text");
     final StringBuilder out = new StringBuilder(text.length());
-    final Alignment.Builder alignment = new Alignment.Builder();
+    final Alignment.Builder alignment = new Alignment.Builder(text.length());
     final int length = text.length();
     int i = 0;
     while (i < length) {
@@ -725,7 +725,7 @@ public final class CharClass {
     requireNonNullArg(text, "text");
     requireNonNullArg(substitution, "substitution");
     final StringBuilder out = new StringBuilder(text.length());
-    final Alignment.Builder alignment = new Alignment.Builder();
+    final Alignment.Builder alignment = new Alignment.Builder(text.length());
     final int length = text.length();
     int i = 0;
     while (i < length) {

--- a/opennlp-api/src/main/java/opennlp/tools/util/normalizer/CharClass.java
+++ b/opennlp-api/src/main/java/opennlp/tools/util/normalizer/CharClass.java
@@ -30,9 +30,12 @@ import opennlp.tools.util.Span;
  * presets ({@link #whitespace()}, {@link #dashes()}); any other class is one more configured
  * instance with no new engine code.</p>
  *
- * <p>Every operation is a single forward pass that reads one code point
- * ({@link Character#codePointAt(CharSequence, int)}), tests membership in O(1), acts, and advances
- * by {@link Character#charCount(int)}. There is no regular expression, no {@link java.util.regex}
+ * <p>Every operation is a single forward pass that reads one code point, tests membership in
+ * O(1), acts, and advances. A {@code char} that is not a high surrogate is its own code point, so
+ * BMP text (the overwhelming majority of input) decodes without
+ * {@link Character#codePointAt(CharSequence, int)} pairing or a separate
+ * {@link Character#charCount(int)} test; only a high surrogate takes the supplementary decode.
+ * There is no regular expression, no {@link java.util.regex}
  * allocation, and no reliance on {@link Character#isWhitespace(int)} or
  * {@link Character#isSpaceChar(int)}, all of which disagree with the Unicode standard.</p>
  *
@@ -130,7 +133,16 @@ public final class CharClass {
     int tokenStart = -1;
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         if (tokenStart >= 0) {
           spans.add(new Span(tokenStart, i));
@@ -139,7 +151,7 @@ public final class CharClass {
       } else if (tokenStart < 0) {
         tokenStart = i;
       }
-      i += Character.charCount(codePoint);
+      i += charCount;
     }
     if (tokenStart >= 0) {
       spans.add(new Span(tokenStart, length));
@@ -187,9 +199,18 @@ public final class CharClass {
     final StringBuilder out = new StringBuilder(length).append(text, 0, first);
     int i = first;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       out.appendCodePoint(members.contains(codePoint) ? replacement : codePoint);
-      i += Character.charCount(codePoint);
+      i += charCount;
     }
     return out.toString();
   }
@@ -220,13 +241,22 @@ public final class CharClass {
     final StringBuilder out = new StringBuilder(length).append(text, 0, first);
     int i = first;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         out.appendCodePoint(replacement);
         i = skipRun(text, i);
       } else {
         out.appendCodePoint(codePoint);
-        i += Character.charCount(codePoint);
+        i += charCount;
       }
     }
     return out.toString();
@@ -253,23 +283,41 @@ public final class CharClass {
     final int length = text.length();
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         boolean preserve = keep.contains(codePoint);
-        int j = i + Character.charCount(codePoint);
+        int j = i + charCount;
         while (j < length) {
-          final int next = Character.codePointAt(text, j);
+          final char nextChar = text.charAt(j);
+          final int next;
+          final int nextCount;
+          if (!Character.isHighSurrogate(nextChar)) {
+            next = nextChar;
+            nextCount = 1;
+          } else {
+            next = Character.codePointAt(text, j);
+            nextCount = Character.charCount(next);
+          }
           if (!members.contains(next)) {
             break;
           }
           preserve |= keep.contains(next);
-          j += Character.charCount(next);
+          j += nextCount;
         }
         out.appendCodePoint(preserve ? keepReplacement : replacement);
         i = j;
       } else {
         out.appendCodePoint(codePoint);
-        i += Character.charCount(codePoint);
+        i += charCount;
       }
     }
     return out.toString();
@@ -287,19 +335,37 @@ public final class CharClass {
     final int length = text.length();
     int start = 0;
     while (start < length) {
-      final int codePoint = Character.codePointAt(text, start);
+      final char c = text.charAt(start);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, start);
+        charCount = Character.charCount(codePoint);
+      }
       if (!members.contains(codePoint)) {
         break;
       }
-      start += Character.charCount(codePoint);
+      start += charCount;
     }
     int end = length;
     while (end > start) {
-      final int codePoint = Character.codePointBefore(text, end);
+      final char c = text.charAt(end - 1);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isLowSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointBefore(text, end);
+        charCount = Character.charCount(codePoint);
+      }
       if (!members.contains(codePoint)) {
         break;
       }
-      end -= Character.charCount(codePoint);
+      end -= charCount;
     }
     return text.subSequence(start, end).toString();
   }
@@ -325,11 +391,20 @@ public final class CharClass {
     final StringBuilder out = new StringBuilder(length).append(text, 0, first);
     int i = first;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (!members.contains(codePoint)) {
         out.appendCodePoint(codePoint);
       }
-      i += Character.charCount(codePoint);
+      i += charCount;
     }
     return out.toString();
   }
@@ -349,8 +424,16 @@ public final class CharClass {
     final int length = text.length();
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
-      final int charCount = Character.charCount(codePoint);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         out.appendCodePoint(replacement);
         alignment.replace(charCount, Character.charCount(replacement));
@@ -378,14 +461,22 @@ public final class CharClass {
     final int length = text.length();
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         final int runEnd = skipRun(text, i);
         out.appendCodePoint(replacement);
         alignment.replace(runEnd - i, Character.charCount(replacement));
         i = runEnd;
       } else {
-        final int charCount = Character.charCount(codePoint);
         out.appendCodePoint(codePoint);
         alignment.equal(charCount);
         i += charCount;
@@ -415,24 +506,41 @@ public final class CharClass {
     final int length = text.length();
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         boolean preserve = keep.contains(codePoint);
-        int j = i + Character.charCount(codePoint);
+        int j = i + charCount;
         while (j < length) {
-          final int next = Character.codePointAt(text, j);
+          final char nextChar = text.charAt(j);
+          final int next;
+          final int nextCount;
+          if (!Character.isHighSurrogate(nextChar)) {
+            next = nextChar;
+            nextCount = 1;
+          } else {
+            next = Character.codePointAt(text, j);
+            nextCount = Character.charCount(next);
+          }
           if (!members.contains(next)) {
             break;
           }
           preserve |= keep.contains(next);
-          j += Character.charCount(next);
+          j += nextCount;
         }
         final int emitted = preserve ? keepReplacement : replacement;
         out.appendCodePoint(emitted);
         alignment.replace(j - i, Character.charCount(emitted));
         i = j;
       } else {
-        final int charCount = Character.charCount(codePoint);
         out.appendCodePoint(codePoint);
         alignment.equal(charCount);
         i += charCount;
@@ -455,19 +563,37 @@ public final class CharClass {
     final int length = text.length();
     int start = 0;
     while (start < length) {
-      final int codePoint = Character.codePointAt(text, start);
+      final char c = text.charAt(start);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, start);
+        charCount = Character.charCount(codePoint);
+      }
       if (!members.contains(codePoint)) {
         break;
       }
-      start += Character.charCount(codePoint);
+      start += charCount;
     }
     int end = length;
     while (end > start) {
-      final int codePoint = Character.codePointBefore(text, end);
+      final char c = text.charAt(end - 1);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isLowSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointBefore(text, end);
+        charCount = Character.charCount(codePoint);
+      }
       if (!members.contains(codePoint)) {
         break;
       }
-      end -= Character.charCount(codePoint);
+      end -= charCount;
     }
     final Alignment.Builder alignment = new Alignment.Builder();
     if (start > 0) {
@@ -495,8 +621,16 @@ public final class CharClass {
     final int length = text.length();
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
-      final int charCount = Character.charCount(codePoint);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         alignment.replace(charCount, 0);
       } else {
@@ -535,8 +669,15 @@ public final class CharClass {
     int first = 0;
     int firstCount = 0;
     while (first < length) {
-      final int codePoint = Character.codePointAt(text, first);
-      firstCount = Character.charCount(codePoint);
+      final char c = text.charAt(first);
+      final int codePoint;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        firstCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, first);
+        firstCount = Character.charCount(codePoint);
+      }
       firstReplacement = substitution.apply(codePoint);
       if (firstReplacement != null) {
         break;
@@ -550,14 +691,23 @@ public final class CharClass {
         new StringBuilder(length).append(text, 0, first).append(firstReplacement);
     int i = first + firstCount;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       final String replacement = substitution.apply(codePoint);
       if (replacement != null) {
         out.append(replacement);
       } else {
         out.appendCodePoint(codePoint);
       }
-      i += Character.charCount(codePoint);
+      i += charCount;
     }
     return out.toString();
   }
@@ -579,8 +729,16 @@ public final class CharClass {
     final int length = text.length();
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
-      final int charCount = Character.charCount(codePoint);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       final String replacement = substitution.apply(codePoint);
       if (replacement != null) {
         out.append(replacement);
@@ -600,11 +758,20 @@ public final class CharClass {
     final int length = text.length();
     int i = 0;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (members.contains(codePoint)) {
         return i;
       }
-      i += Character.charCount(codePoint);
+      i += charCount;
     }
     return length;
   }
@@ -614,11 +781,20 @@ public final class CharClass {
     final int length = text.length();
     int i = runStart;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       if (!members.contains(codePoint)) {
         break;
       }
-      i += Character.charCount(codePoint);
+      i += charCount;
     }
     return i;
   }

--- a/opennlp-api/src/main/java/opennlp/tools/util/normalizer/CharClass.java
+++ b/opennlp-api/src/main/java/opennlp/tools/util/normalizer/CharClass.java
@@ -167,15 +167,25 @@ public final class CharClass {
   /**
    * Replaces each member code point with the replacement, one for one.
    *
+   * <p>When no code point of {@code text} is a member, the text is returned unchanged (as its
+   * {@link CharSequence#toString() string form}) without copying.</p>
+   *
    * @param text The text to normalize.
    * @return The normalized text.
    * @throws IllegalArgumentException Thrown if {@code text} is {@code null}.
    */
   public String normalize(CharSequence text) {
     requireNonNullArg(text, "text");
-    final StringBuilder out = new StringBuilder(text.length());
     final int length = text.length();
-    int i = 0;
+    // Scan-then-fold: find the first member without allocating. Member-free text (the common case
+    // on ASCII-heavy token streams) is returned unchanged; otherwise the fold loop starts from a
+    // builder pre-filled with the unchanged prefix and runs branch-free from there.
+    final int first = firstMember(text);
+    if (first == length) {
+      return text.toString();
+    }
+    final StringBuilder out = new StringBuilder(length).append(text, 0, first);
+    int i = first;
     while (i < length) {
       final int codePoint = Character.codePointAt(text, i);
       out.appendCodePoint(members.contains(codePoint) ? replacement : codePoint);
@@ -192,15 +202,23 @@ public final class CharClass {
    * the empty string). Use {@link #trim(CharSequence)} to drop edge members, or collapse and then
    * trim to do both.</p>
    *
+   * <p>When no code point of {@code text} is a member, the text is returned unchanged (as its
+   * {@link CharSequence#toString() string form}) without copying.</p>
+   *
    * @param text The text to collapse.
    * @return The collapsed text.
    * @throws IllegalArgumentException Thrown if {@code text} is {@code null}.
    */
   public String collapse(CharSequence text) {
     requireNonNullArg(text, "text");
-    final StringBuilder out = new StringBuilder(text.length());
     final int length = text.length();
-    int i = 0;
+    // Scan-then-fold, as in normalize(CharSequence).
+    final int first = firstMember(text);
+    if (first == length) {
+      return text.toString();
+    }
+    final StringBuilder out = new StringBuilder(length).append(text, 0, first);
+    int i = first;
     while (i < length) {
       final int codePoint = Character.codePointAt(text, i);
       if (members.contains(codePoint)) {
@@ -289,15 +307,23 @@ public final class CharClass {
   /**
    * Removes every member code point.
    *
+   * <p>When no code point of {@code text} is a member, the text is returned unchanged (as its
+   * {@link CharSequence#toString() string form}) without copying.</p>
+   *
    * @param text The text to filter.
    * @return The text with all members removed.
    * @throws IllegalArgumentException Thrown if {@code text} is {@code null}.
    */
   public String removeAll(CharSequence text) {
     requireNonNullArg(text, "text");
-    final StringBuilder out = new StringBuilder(text.length());
     final int length = text.length();
-    int i = 0;
+    // Scan-then-fold, as in normalize(CharSequence).
+    final int first = firstMember(text);
+    if (first == length) {
+      return text.toString();
+    }
+    final StringBuilder out = new StringBuilder(length).append(text, 0, first);
+    int i = first;
     while (i < length) {
       final int codePoint = Character.codePointAt(text, i);
       if (!members.contains(codePoint)) {
@@ -488,6 +514,10 @@ public final class CharClass {
    * offset-changing cursor pass behind the expanding folds (ellipsis, German umlaut, digit), so each
    * of them supplies only a mapper rather than re-implementing the loop. No regular expression.
    *
+   * <p>When {@code substitution} returns {@code null} for every code point of {@code text}, the
+   * text is returned unchanged (as its {@link CharSequence#toString() string form}) without
+   * copying. The mapper is still applied exactly once per code point.</p>
+   *
    * @param text         The text to transform.
    * @param substitution The replacement for a code point, or {@code null} to copy it through.
    * @return The transformed text.
@@ -496,9 +526,29 @@ public final class CharClass {
   public static String substitute(CharSequence text, IntFunction<String> substitution) {
     requireNonNullArg(text, "text");
     requireNonNullArg(substitution, "substitution");
-    final StringBuilder out = new StringBuilder(text.length());
     final int length = text.length();
-    int i = 0;
+    // Scan-then-fold, applying the mapper exactly once per code point: scan until the mapper
+    // first fires; text the mapper leaves entirely alone is returned unchanged without copying,
+    // and otherwise the fold continues from a builder pre-filled with the unchanged prefix and
+    // the first replacement.
+    String firstReplacement = null;
+    int first = 0;
+    int firstCount = 0;
+    while (first < length) {
+      final int codePoint = Character.codePointAt(text, first);
+      firstCount = Character.charCount(codePoint);
+      firstReplacement = substitution.apply(codePoint);
+      if (firstReplacement != null) {
+        break;
+      }
+      first += firstCount;
+    }
+    if (firstReplacement == null) {
+      return text.toString();
+    }
+    final StringBuilder out =
+        new StringBuilder(length).append(text, 0, first).append(firstReplacement);
+    int i = first + firstCount;
     while (i < length) {
       final int codePoint = Character.codePointAt(text, i);
       final String replacement = substitution.apply(codePoint);
@@ -542,6 +592,21 @@ public final class CharClass {
       i += charCount;
     }
     return new AlignedText(text, out.toString(), alignment.build(length));
+  }
+
+  // Returns the offset of the first member code point, or the text length if there is none. The
+  // allocation-free scan phase shared by the folds that return member-free text unchanged.
+  private int firstMember(CharSequence text) {
+    final int length = text.length();
+    int i = 0;
+    while (i < length) {
+      final int codePoint = Character.codePointAt(text, i);
+      if (members.contains(codePoint)) {
+        return i;
+      }
+      i += Character.charCount(codePoint);
+    }
+    return length;
   }
 
   // Returns the offset just past the maximal run of members starting at runStart.

--- a/opennlp-api/src/test/java/opennlp/tools/util/normalizer/AlignmentTest.java
+++ b/opennlp-api/src/test/java/opennlp/tools/util/normalizer/AlignmentTest.java
@@ -157,6 +157,38 @@ public class AlignmentTest {
   }
 
   @Test
+  void testPreSizedBuilderMatchesDefaultBuilder() {
+    // The pre-size constructor is a capacity hint only: same edits, same alignment.
+    final Alignment sized = new Alignment.Builder(4).equal(1).replace(2, 1).equal(1).build(4);
+    final Alignment grown = new Alignment.Builder().equal(1).replace(2, 1).equal(1).build(4);
+    assertEquals(grown.normalizedLength(), sized.normalizedLength());
+    assertEquals(grown.originalLength(), sized.originalLength());
+    for (int i = 0; i <= sized.normalizedLength(); i++) {
+      assertEquals(grown.toOriginalOffset(i), sized.toOriginalOffset(i));
+    }
+    assertSpan(1, 3, sized.toOriginalSpan(1, 2));
+  }
+
+  @Test
+  void testPreSizedBuilderIsAHintNotALimit() {
+    // Recording more edits than the hint must grow, not fail.
+    final Alignment a = new Alignment.Builder(2).equal(40).build(40);
+    assertEquals(40, a.normalizedLength());
+    assertSpan(0, 40, a.toOriginalSpan(0, 40));
+  }
+
+  @Test
+  void testPreSizedBuilderAcceptsZero() {
+    final Alignment a = new Alignment.Builder(0).equal(3).build(3);
+    assertEquals(3, a.normalizedLength());
+  }
+
+  @Test
+  void testPreSizedBuilderRejectsNegativeLength() {
+    assertThrows(IllegalArgumentException.class, () -> new Alignment.Builder(-1));
+  }
+
+  @Test
   void testAndThenChainsThreeStages() {
     // "a  b" -> "a b" (collapse) -> "a-b" (space->dash) -> "a_b" (dash->underscore).
     final Alignment s1 = new Alignment.Builder().equal(1).replace(2, 1).equal(1).build(4);

--- a/opennlp-api/src/test/java/opennlp/tools/util/normalizer/CharClassTest.java
+++ b/opennlp-api/src/test/java/opennlp/tools/util/normalizer/CharClassTest.java
@@ -17,6 +17,7 @@
 package opennlp.tools.util.normalizer;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,7 @@ import opennlp.tools.util.normalizer.UnicodeWhitespace.WhitespaceCharacter;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -152,6 +154,77 @@ public class CharClassTest {
   @Test
   void testRemoveAll() {
     assertEquals("abcd", WS.removeAll("a b\tc d"));
+  }
+
+  // --- identity short-circuit (member-free input is returned uncopied) ----------------------
+
+  @Test
+  void testNormalizeReturnsSameInstanceWhenNoMember() {
+    final String text = "plain ascii token";
+    assertSame(text, DASH.normalize(text), "member-free input must be returned uncopied");
+    final String noWhitespace = "token";
+    assertSame(noWhitespace, WS.normalize(noWhitespace));
+  }
+
+  @Test
+  void testCollapseReturnsSameInstanceWhenNoMember() {
+    final String text = "token";
+    assertSame(text, WS.collapse(text));
+    assertSame(text, DASH.collapse(text));
+  }
+
+  @Test
+  void testRemoveAllReturnsSameInstanceWhenNoMember() {
+    final String text = "token" + GRINNING_FACE;
+    assertSame(text, WS.removeAll(text));
+    assertSame(text, DASH.removeAll(text));
+  }
+
+  @Test
+  void testSubstituteReturnsSameInstanceWhenMapperNeverFires() {
+    final String text = "token 123";
+    assertSame(text, CharClass.substitute(text, codePoint -> null));
+  }
+
+  @Test
+  void testIdentityShortCircuitConvertsNonStringInput() {
+    final StringBuilder text = new StringBuilder("token");
+    assertEquals("token", WS.normalize(text), "a CharSequence input still yields its string form");
+    assertEquals("token", WS.collapse(text));
+    assertEquals("token", WS.removeAll(text));
+    assertEquals("token", CharClass.substitute(text, codePoint -> null));
+  }
+
+  @Test
+  void testLazyBuilderCopiesUnchangedPrefixBeforeFirstMember() {
+    // The first member appears after a supplementary character, so the pre-filled prefix must be
+    // copied by chars, not code points, to stay byte-identical.
+    final String text = GRINNING_FACE + "ab" + NBSP + NBSP + "cd";
+    assertEquals(GRINNING_FACE + "ab  cd", WS.normalize(text));
+    assertEquals(GRINNING_FACE + "ab cd", WS.collapse(text));
+    assertEquals(GRINNING_FACE + "abcd", WS.removeAll(text));
+    assertEquals(GRINNING_FACE + "ab__cd",
+        CharClass.substitute(text, codePoint -> codePoint == 0x00A0 ? "_" : null));
+  }
+
+  @Test
+  void testSubstituteAppliesMapperOncePerCodePoint() {
+    final String text = "a" + GRINNING_FACE + "1b2";
+    final AtomicInteger calls = new AtomicInteger();
+    final String unchanged = CharClass.substitute(text, codePoint -> {
+      calls.incrementAndGet();
+      return null;
+    });
+    assertSame(text, unchanged);
+    assertEquals(5, calls.get(), "the mapper must be applied exactly once per code point");
+
+    calls.set(0);
+    final String replaced = CharClass.substitute(text, codePoint -> {
+      calls.incrementAndGet();
+      return Character.isDigit(codePoint) ? "#" : null;
+    });
+    assertEquals("a" + GRINNING_FACE + "#b#", replaced);
+    assertEquals(5, calls.get(), "the lazy builder must not re-apply the mapper");
   }
 
   // --- split / splitSpans ------------------------------------------------------------------

--- a/opennlp-api/src/test/java/opennlp/tools/util/normalizer/CharClassTest.java
+++ b/opennlp-api/src/test/java/opennlp/tools/util/normalizer/CharClassTest.java
@@ -227,6 +227,21 @@ public class CharClassTest {
     assertEquals(5, calls.get(), "the lazy builder must not re-apply the mapper");
   }
 
+  // --- BMP fast path: unpaired surrogates must decode exactly like Character.codePointAt ----
+
+  @Test
+  void testUnpairedSurrogatesPassThroughUnchanged() {
+    final String loneHigh = "\uD83D"; // high surrogate with no low surrogate following
+    final String loneLow = "\uDE00";  // low surrogate with no high surrogate preceding
+    final String text = "a" + loneHigh + " " + loneLow + "b";
+    assertEquals(text, WS.normalize(text));
+    assertEquals(text, WS.collapse(text));
+    assertEquals("a" + loneHigh + loneLow + "b", WS.removeAll(text));
+    assertEquals(text, WS.trim(" " + text + "\t"));
+    assertArrayEquals(new String[] {"a" + loneHigh, loneLow + "b"}, WS.split(text));
+    assertEquals(text, CharClass.substitute(text, codePoint -> null));
+  }
+
   // --- split / splitSpans ------------------------------------------------------------------
 
   @Test

--- a/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/AbstractDL.java
+++ b/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/AbstractDL.java
@@ -415,8 +415,8 @@ public abstract class AbstractDL implements AutoCloseable {
   // An AlignedText whose alignment is the identity, for the case where no length-changing fold was
   // applied so the folded text has the same length and offsets as the original.
   private static AlignedText identityAligned(final String original, final String normalized) {
-    final Alignment alignment =
-        new Alignment.Builder().equal(normalized.length()).build(normalized.length());
+    final Alignment alignment = new Alignment.Builder(normalized.length())
+        .equal(normalized.length()).build(normalized.length());
     return new AlignedText(original, normalized, alignment);
   }
 

--- a/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/doccat/DocumentCategorizerDL.java
+++ b/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/doccat/DocumentCategorizerDL.java
@@ -22,10 +22,10 @@ import java.io.IOException;
 import java.nio.LongBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -214,7 +214,7 @@ public class DocumentCategorizerDL extends AbstractDL implements DocumentCategor
           "The document to categorize must contain at least one non-whitespace token");
     }
 
-    final List<double[]> scores = new LinkedList<>();
+    final List<double[]> scores = new ArrayList<>(tokens.size());
     for (final Tokens t : tokens) {
       scores.add(softmax(infer(t)));
     }
@@ -240,7 +240,8 @@ public class DocumentCategorizerDL extends AbstractDL implements DocumentCategor
    */
   private float[] infer(final Tokens t) {
 
-    final Map<String, OnnxTensor> inputs = new HashMap<>();
+    // At most three inputs (ids, attention mask, token type ids), so size for exactly that.
+    final Map<String, OnnxTensor> inputs = HashMap.newHashMap(3);
     final Object output;
     try {
       inputs.put(INPUT_IDS, OnnxTensor.createTensor(env,
@@ -367,12 +368,13 @@ public class DocumentCategorizerDL extends AbstractDL implements DocumentCategor
   private List<Tokens> tokenize(final String input) {
 
     final String text = normalizeInput(input, normalizeWhitespace, normalizeDashes);
-    final List<Tokens> t = new LinkedList<>();
 
     // Segment long input text into overlapping chunks (split on Unicode whitespace) configured by
     // InferenceOptions before feeding each chunk into BERT.
     // https://medium.com/analytics-vidhya/text-classification-with-bert-using-transformers-for-long-text-inputs-f54833994dfd
-    for (final String group : whitespaceChunks(text, documentSplitSize, splitOverlapSize)) {
+    final List<String> groups = whitespaceChunks(text, documentSplitSize, splitOverlapSize);
+    final List<Tokens> t = new ArrayList<>(groups.size());
+    for (final String group : groups) {
 
       // Now we can tokenize the group and continue.
       final String[] tokens = tokenizer.tokenize(group);

--- a/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/namefinder/NameFinderDL.java
+++ b/opennlp-core/opennlp-ml/opennlp-dl/src/main/java/opennlp/dl/namefinder/NameFinderDL.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -352,7 +351,8 @@ public class NameFinderDL extends AbstractDL implements OffsetMappingNameFinder 
    */
   private float[][] infer(final Tokens tokens) {
 
-    final Map<String, OnnxTensor> inputs = new HashMap<>();
+    // At most three inputs (ids, attention mask, token type ids), so size for exactly that.
+    final Map<String, OnnxTensor> inputs = HashMap.newHashMap(3);
     final Object output;
     try {
       inputs.put(INPUT_IDS, OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.ids()),
@@ -781,13 +781,13 @@ public class NameFinderDL extends AbstractDL implements OffsetMappingNameFinder 
 
   private List<ChunkTokens> tokenize(final String text) {
 
-    final List<ChunkTokens> t = new LinkedList<>();
-
     // Segment long input text into overlapping chunks (split on Unicode whitespace) configured by
     // InferenceOptions before feeding each chunk into BERT, keeping each chunk's character span so
     // its decoded spans can be bounded to the region the chunk covers.
     // https://medium.com/analytics-vidhya/text-classification-with-bert-using-transformers-for-long-text-inputs-f54833994dfd
-    for (final TextChunk chunk : whitespaceChunkSpans(text, documentSplitSize, splitOverlapSize)) {
+    final List<TextChunk> chunks = whitespaceChunkSpans(text, documentSplitSize, splitOverlapSize);
+    final List<ChunkTokens> t = new ArrayList<>(chunks.size());
+    for (final TextChunk chunk : chunks) {
 
       // Now we can tokenize the group and continue.
       final String[] tokens = tokenizer.tokenize(chunk.text());

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/tokenize/uax29/WordSegmenter.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/tokenize/uax29/WordSegmenter.java
@@ -172,7 +172,19 @@ public final class WordSegmenter {
     final WordBreakProperty.Data wbData = WordBreakProperty.data();
     final BitSet pictographs = ExtendedPictographic.members();
 
-    final int firstCp = Character.codePointAt(text, 0);
+    // Decoding takes the BMP fast path throughout this class: a char that is not a high surrogate
+    // is its own code point, so the common case skips Character.codePointAt's pairing test and a
+    // separate Character.charCount call; only a high surrogate takes the supplementary decode.
+    final char firstChar = text.charAt(0);
+    final int firstCp;
+    final int firstCount;
+    if (!Character.isHighSurrogate(firstChar)) {
+      firstCp = firstChar;
+      firstCount = 1;
+    } else {
+      firstCp = Character.codePointAt(text, 0);
+      firstCount = Character.charCount(firstCp);
+    }
     int prev = WordBreakProperty.ordinalOf(wbData, firstCp);
     boolean prevSpecial = SPECIAL[prev];
     int last = OTHER_ORDINAL;
@@ -184,10 +196,18 @@ public final class WordSegmenter {
     }
 
     int segmentStart = 0;
-    int i = Character.charCount(firstCp);
+    int i = firstCount;
     while (i < length) {
-      final int codePoint = Character.codePointAt(text, i);
-      final int charCount = Character.charCount(codePoint);
+      final char c = text.charAt(i);
+      final int codePoint;
+      final int charCount;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        charCount = 1;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        charCount = Character.charCount(codePoint);
+      }
       final int current = WordBreakProperty.ordinalOf(wbData, codePoint);
 
       // One table read per character. It is the decision for the common case and, as GO_SLOW, the
@@ -296,12 +316,19 @@ public final class WordSegmenter {
   private static WordBreak nextSignificant(CharSequence text, int from, int length,
       WordBreakProperty.Data wbData) {
     for (int j = from; j < length; ) {
-      final int codePoint = Character.codePointAt(text, j);
+      final char c = text.charAt(j);
+      final int codePoint;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        j++;
+      } else {
+        codePoint = Character.codePointAt(text, j);
+        j += Character.charCount(codePoint);
+      }
       final WordBreak value = WordBreakProperty.of(wbData, codePoint);
       if (!isIgnorable(value)) {
         return value;
       }
-      j += Character.charCount(codePoint);
     }
     return WordBreak.OTHER;
   }

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/tokenize/uax29/WordType.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/tokenize/uax29/WordType.java
@@ -100,8 +100,17 @@ public enum WordType {
     // behind ExtendedPictographic.members() is not repeated for every non-ASCII character of a token.
     final BitSet pictographs = ExtendedPictographic.members();
     for (int i = start; i < end; ) {
-      final int codePoint = Character.codePointAt(text, i);
-      i += Character.charCount(codePoint);
+      // BMP fast path: a char that is not a high surrogate is its own code point, so the common
+      // case skips Character.codePointAt's pairing test and a separate Character.charCount call.
+      final char c = text.charAt(i);
+      final int codePoint;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        i++;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        i += Character.charCount(codePoint);
+      }
       if (codePoint < 0x80) {
         final int kind = ASCII_KIND[codePoint];
         if (kind == 1) {

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/normalizer/AlignedAggregateCharSequenceNormalizer.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/normalizer/AlignedAggregateCharSequenceNormalizer.java
@@ -50,7 +50,8 @@ final class AlignedAggregateCharSequenceNormalizer implements OffsetAwareNormali
       // from the stored original for a CharSequence whose length() differs from its toString().
       final String identity = text.toString();
       return new AlignedText(identity, identity,
-          new Alignment.Builder().equal(identity.length()).build(identity.length()));
+          new Alignment.Builder(identity.length()).equal(identity.length())
+              .build(identity.length()));
     }
     // Normalize the input to a String once so the stored original and the per-stage alignment
     // lengths agree even for a CharSequence whose length() differs from its toString().

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/normalizer/Confusables.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/normalizer/Confusables.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,32 +50,41 @@ public final class Confusables {
 
   private static final String RESOURCE = "confusables.txt";
 
-  // Maps a single confusable code point to its prototype sequence (one or more code points).
-  private static volatile Map<Integer, String> prototypes;
+  // The prototype map plus a BitSet over its keys, so the hot no-mapping test is one O(1) bit read
+  // with no Integer boxing. Immutable after construction; published through the volatile field.
+  private record Data(Map<Integer, String> prototypes, BitSet keys) {
+  }
+
+  private static volatile Data data;
 
   private Confusables() {
   }
 
-  private static Map<Integer, String> prototypes() {
-    Map<Integer, String> map = prototypes;
-    if (map == null) {
+  private static Data data() {
+    Data d = data;
+    if (d == null) {
       synchronized (Confusables.class) {
-        map = prototypes;
-        if (map == null) {
-          map = load();
-          prototypes = map;
+        d = data;
+        if (d == null) {
+          d = load();
+          data = d;
         }
       }
     }
-    return map;
+    return d;
   }
 
-  private static Map<Integer, String> load() {
+  private static Data load() {
     try (InputStream in = Confusables.class.getResourceAsStream(RESOURCE)) {
       if (in == null) {
         throw new IllegalStateException("Missing confusables data resource: " + RESOURCE);
       }
-      return parse(in);
+      final Map<Integer, String> prototypes = parse(in);
+      final BitSet keys = new BitSet();
+      for (final int codePoint : prototypes.keySet()) {
+        keys.set(codePoint);
+      }
+      return new Data(prototypes, keys);
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to read confusables data resource " + RESOURCE, e);
     }
@@ -142,13 +152,51 @@ public final class Confusables {
    * @return The skeleton.
    */
   public static String skeleton(CharSequence text) {
-    final Map<Integer, String> map = prototypes();
+    final Data data = data();
+    final BitSet keys = data.keys();
+
+    // Fast path: when no code point of the text is a prototype key and the text is already in
+    // NFD form (trivially true for pure ASCII, which never decomposes), the skeleton is the text
+    // itself: NFD(text) == text, the map pass changes nothing because no key occurs, and the
+    // second NFD of an unchanged NFD string is again the identity. This skips both Normalizer
+    // passes and all allocation for the common clean-token case. Text that fails either test
+    // (a key, or a non-ASCII code point in un-normalized form) takes the full UTS #39 path below,
+    // whose two NFD passes remain required.
+    final int length = text.length();
+    boolean asciiOnly = true;
+    boolean anyKey = false;
+    int i = 0;
+    while (i < length) {
+      final char c = text.charAt(i);
+      final int codePoint;
+      if (!Character.isHighSurrogate(c)) {
+        codePoint = c;
+        i++;
+      } else {
+        codePoint = Character.codePointAt(text, i);
+        i += Character.charCount(codePoint);
+      }
+      if (codePoint >= 0x80) {
+        asciiOnly = false;
+      }
+      if (keys.get(codePoint)) {
+        anyKey = true;
+        break;
+      }
+    }
+    if (!anyKey && (asciiOnly || Normalizer.isNormalized(text, Normalizer.Form.NFD))) {
+      return text.toString();
+    }
+
+    final Map<Integer, String> map = data.prototypes();
     final String decomposed = Normalizer.normalize(text, Normalizer.Form.NFD);
     final StringBuilder mapped = new StringBuilder(decomposed.length());
-    for (int i = 0; i < decomposed.length(); ) {
-      final int codePoint = decomposed.codePointAt(i);
-      i += Character.charCount(codePoint);
-      final String prototype = map.get(codePoint);
+    for (int j = 0; j < decomposed.length(); ) {
+      final int codePoint = decomposed.codePointAt(j);
+      j += Character.charCount(codePoint);
+      // The BitSet pre-filter keeps the common miss free of Integer boxing; only an actual key
+      // pays for the boxed map lookup.
+      final String prototype = keys.get(codePoint) ? map.get(codePoint) : null;
       if (prototype != null) {
         mapped.append(prototype);
       } else {

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/normalizer/DigitCharSequenceNormalizer.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/normalizer/DigitCharSequenceNormalizer.java
@@ -32,6 +32,11 @@ public class DigitCharSequenceNormalizer implements OffsetAwareNormalizer {
 
   private static final DigitCharSequenceNormalizer INSTANCE = new DigitCharSequenceNormalizer();
 
+  // The ten ASCII digit strings, precomputed so the mapper does not allocate a new single-char
+  // String for every digit it folds.
+  private static final String[] ASCII_DIGITS =
+      {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+
   /** {@return the shared, stateless instance} */
   public static DigitCharSequenceNormalizer getInstance() {
     return INSTANCE;
@@ -43,9 +48,12 @@ public class DigitCharSequenceNormalizer implements OffsetAwareNormalizer {
   }
 
   // The ASCII digit for a Unicode decimal digit code point, or null to copy the code point through.
+  // An ASCII digit is already its own fold, so it reports null and takes the copy-through path;
+  // the substitution and its alignment are identical either way (a one-for-one replacement records
+  // the same alignment run as a copy), and text whose digits are all ASCII is returned uncopied.
   private static String toAscii(int codePoint) {
     final int value = Character.digit(codePoint, 10);
-    return value >= 0 ? String.valueOf((char) ('0' + value)) : null;
+    return value >= 0 && codePoint != '0' + value ? ASCII_DIGITS[value] : null;
   }
 
   @Override

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/tokenize/uax29/WordSegmenterTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/tokenize/uax29/WordSegmenterTest.java
@@ -98,6 +98,13 @@ public class WordSegmenterTest {
   }
 
   @Test
+  void testUnpairedSurrogatesAdvanceOneCharAndSegmentAsOther() {
+    // A lone high or low surrogate must decode exactly like Character.codePointAt: one char,
+    // Word_Break class Other, so it separates from the letters on both sides.
+    assertEquals(List.of("ab", "\uD800", "cd", "\uDC00", "ef"), words("ab\uD800cd\uDC00ef"));
+  }
+
+  @Test
   void testEmptyText() {
     assertEquals(List.of(), words(""));
     assertArrayEquals(new int[] {0}, WordSegmenter.boundaries(""));

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/util/normalizer/ConfusablesTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/util/normalizer/ConfusablesTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConfusablesTest {
@@ -70,6 +71,46 @@ public class ConfusablesTest {
   void testMultipleCyrillicLookalikesFold() {
     final String spoof = "d" + cp(0x0430) + "t" + cp(0x0430); // "data" with Cyrillic a's
     assertEquals(Confusables.skeleton("data"), Confusables.skeleton(spoof));
+  }
+
+  @Test
+  void testSkeletonReturnsCleanAsciiUnchanged() {
+    // No code point of the text is a prototype key, so the fast path returns the input as-is.
+    final String clean = "hello";
+    assertSame(clean, Confusables.skeleton(clean));
+  }
+
+  @Test
+  void testSkeletonStillMapsAsciiPrototypeKeys() {
+    // ASCII code points that ARE prototype keys must defeat the fast path and map as before.
+    assertEquals("rn", Confusables.skeleton("m"));
+    assertEquals("l", Confusables.skeleton("I"));
+    assertEquals("l", Confusables.skeleton("1"));
+    assertEquals("O", Confusables.skeleton("0"));
+    assertEquals("corn", Confusables.skeleton("com"));
+  }
+
+  @Test
+  void testSkeletonStillDecomposesPrecomposedText() {
+    // A precomposed character is not in NFD form, so it must take the full path and decompose,
+    // and the result must agree with the already-decomposed spelling (canonical equivalence).
+    final String precomposed = cp(0x00E9);          // e with acute, single code point
+    final String decomposed = "e" + cp(0x0301);     // e + combining acute
+    assertEquals(decomposed, Confusables.skeleton(precomposed));
+    assertEquals(Confusables.skeleton(precomposed), Confusables.skeleton(decomposed));
+  }
+
+  @Test
+  void testSkeletonReturnsNfdStableNonKeyTextUnchanged() {
+    // Non-ASCII, already in NFD form, and no prototype key: the fast path applies.
+    final String hiragana = cp(0x3042);
+    assertSame(hiragana, Confusables.skeleton(hiragana));
+  }
+
+  @Test
+  void testSkeletonStillMapsNonAsciiPrototypeKeys() {
+    // U+4E00 is a prototype key (maps to the prolonged sound mark), so it must still map.
+    assertEquals(cp(0x30FC), Confusables.skeleton(cp(0x4E00)));
   }
 
   @Test

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/util/normalizer/SetBasedNormalizerTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/util/normalizer/SetBasedNormalizerTest.java
@@ -96,6 +96,13 @@ public class SetBasedNormalizerTest {
     assertSame(DigitCharSequenceNormalizer.getInstance(), DigitCharSequenceNormalizer.getInstance());
   }
 
+  @Test
+  void testDigitsReturnAsciiDigitTextUncopied() {
+    // ASCII digits are already their own fold, so digit-clean text short-circuits uncopied.
+    final String text = "version 42 of 2026";
+    assertSame(text, DigitCharSequenceNormalizer.getInstance().normalize(text));
+  }
+
   // --- invisible / bidi controls -----------------------------------------------------------
 
   @Test


### PR DESCRIPTION
Draft, stacked on `OPENNLP-1850-3-dl` (PR #1105): this base is deliberate, not a mistake. #1105 is approved but not yet merged, and the eval-tests-configurable job that validates it is still being worked through; opening this PR against `main` right now would bundle all of #1105's unmerged commits into the diff alongside these 6. Once #1105 merges, this PR gets retargeted to `main` and the branch rebased, at which point the diff naturally collapses to just the 6 commits below.

Non-breaking performance follow-up to OPENNLP-1850 for heavy analyzer/tokenizer use. Six output-preserving changes:

- an identity short-circuit on the non-aligned `CharClass` folds (member-free text returns without allocation),
- a key-`BitSet` fast-path in `Confusables.skeleton` (clean text skips both NFD passes),
- BMP fast-paths in the hot cursor loops,
- precomputed digit strings,
- a pre-sized `Alignment.Builder` constructor,
- up-front sizing of the DL score/token/ONNX collections.

JMH on realistic mixed-script token streams confirms the tier-one wins (identity short-circuit up to 4.3x on whitespace-normalize-heavy streams, Confusables 1.7x) with the predicted neutral result on fold-saturated text.

Byte-identical output; the full 1850 suites pass unchanged (api 298/0, runtime 1304/0, dl 92/0).

https://issues.apache.org/jira/browse/OPENNLP-1878
