### PR TITLE
OPENNLP-1882: Stop excluding stemmer tests and fix stale Turkish expectations

### DIFF
--- a/opennlp-core/opennlp-cli/pom.xml
+++ b/opennlp-core/opennlp-cli/pom.xml
@@ -123,8 +123,6 @@
           <forkCount>${opennlp.forkCount}</forkCount>
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <excludes>
-            <exclude>**/stemmer/*</exclude>
-            <exclude>**/stemmer/snowball/*</exclude>
             <exclude>**/*IT.java</exclude>
           </excludes>
         </configuration>

--- a/opennlp-core/opennlp-formats/pom.xml
+++ b/opennlp-core/opennlp-formats/pom.xml
@@ -95,8 +95,6 @@
           <forkCount>${opennlp.forkCount}</forkCount>
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <excludes>
-            <exclude>**/stemmer/*</exclude>
-            <exclude>**/stemmer/snowball/*</exclude>
             <exclude>**/*IT.java</exclude>
           </excludes>
         </configuration>

--- a/opennlp-core/opennlp-runtime/pom.xml
+++ b/opennlp-core/opennlp-runtime/pom.xml
@@ -108,8 +108,6 @@
           <forkCount>${opennlp.forkCount}</forkCount>
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <excludes>
-            <exclude>**/stemmer/*</exclude>
-            <exclude>**/stemmer/snowball/*</exclude>
             <exclude>**/*IT.java</exclude>
           </excludes>
         </configuration>

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/stemmer/SnowballStemmerTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/stemmer/SnowballStemmerTest.java
@@ -184,9 +184,12 @@ public class SnowballStemmerTest {
   @Test
   void testTurkish() {
     SnowballStemmer stemmer = new SnowballStemmer(ALGORITHM.TURKISH);
-    Assertions.assertEquals("ab'yle", stemmer.stem("ab'yle"));
+    // Expected values follow the reference data at
+    // https://github.com/snowballstem/snowball-data/tree/master/turkish: the Turkish algorithm
+    // removes proper-noun suffixes after an apostrophe (r_remove_proper_noun_suffix).
+    Assertions.assertEquals("ab", stemmer.stem("ab'yle"));
     Assertions.assertEquals("kaçmamak", stemmer.stem("kaçmamaktadır"));
-    Assertions.assertEquals("sarayı'nı", stemmer.stem("sarayı'nı"));
+    Assertions.assertEquals("sara", stemmer.stem("sarayı'nı"));
   }
 
   @Test

--- a/opennlp-tools/pom.xml
+++ b/opennlp-tools/pom.xml
@@ -172,8 +172,6 @@
           <forkCount>${opennlp.forkCount}</forkCount>
           <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
           <excludes>
-            <exclude>**/stemmer/*</exclude>
-            <exclude>**/stemmer/snowball/*</exclude>
             <exclude>**/*IT.java</exclude>
           </excludes>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -365,8 +365,6 @@
 						<forkCount>${opennlp.forkCount}</forkCount>
 						<failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
 						<excludes>
-							<exclude>**/stemmer/*</exclude>
-							<exclude>**/stemmer/snowball/*</exclude>
 							<exclude>**/*IT.java</exclude>
 						</excludes>
 					</configuration>


### PR DESCRIPTION
Thank you for contributing to Apache OpenNLP.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under ASF 2.0?
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

## What is this PR for?

OPENNLP-997 (2017) excluded `**/stemmer/*` and `**/stemmer/snowball/*` from the JaCoCo coverage report to keep generated Snowball code out of coverage metrics. The same excludes were also copied into the surefire configuration (root pom plus opennlp-tools, opennlp-runtime, opennlp-cli, opennlp-formats), so no test under a stemmer package has run in any Maven build since.

This hid a stale test: OPENNLP-1701 regenerated the Snowball code, whose Turkish algorithm now removes proper-noun suffixes after an apostrophe (`r_remove_proper_noun_suffix`), and `SnowballStemmerTest#testTurkish` still expected the old behavior. The updated expectations follow the snowball-data reference vocabulary.

## Changes

- Remove the stemmer excludes from surefire in five poms (the JaCoCo report excludes are kept, so coverage metrics are unchanged)
- Update `SnowballStemmerTest#testTurkish` to the current reference behavior (`ab'yle` -> `ab`, `sarayı'nı` -> `sara`)

This unhides 26 existing stemmer tests. The full reactor build (`mvn clean test verify -Pjacoco -Pci`) passes with them enabled.