### PR TITLE
OPENNLP-1233: Link the POS and chunk tag references

### DIFF
--- a/opennlp-docs/src/docbkx/chunker.xml
+++ b/opennlp-docs/src/docbkx/chunker.xml
@@ -65,7 +65,7 @@ Rockwell_NNP said_VBD the_DT agreement_NN calls_VBZ for_IN it_PRP to_TO supply_V
     [PP for_IN ] [NP the_DT planes_NNS ] ._.]]>
 		</screen>
 		The example uses
-		<link xlink:href="https://catalog.ldc.upenn.edu/docs/LDC95T7/cl93.html">
+		<link xlink:href="https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html">
 			Penn Treebank part-of-speech tags
 		</link> and
 		<link xlink:href="https://aclanthology.org/W00-0726/">

--- a/opennlp-docs/src/docbkx/chunker.xml
+++ b/opennlp-docs/src/docbkx/chunker.xml
@@ -64,9 +64,12 @@ Rockwell_NNP said_VBD the_DT agreement_NN calls_VBZ for_IN it_PRP to_TO supply_V
     [NP it_PRP ] [VP to_TO supply_VB ] [NP 200_CD additional_JJ so-called_JJ shipsets_NNS ]
     [PP for_IN ] [NP the_DT planes_NNS ] ._.]]>
 		</screen>
-		The tag set used by the English pos model is the
-		<link xlink:href="https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html">
-			Penn Treebank tag set
+		The example uses
+		<link xlink:href="https://catalog.ldc.upenn.edu/docs/LDC95T7/cl93.html">
+			Penn Treebank part-of-speech tags
+		</link> and
+		<link xlink:href="https://aclanthology.org/W00-0726/">
+			CoNLL-2000 IOB chunk tags
 		</link>.
 		</para>
 		</section>


### PR DESCRIPTION
## Summary

- describe the two tag systems used by the chunking example separately
- retain the existing Penn Treebank part-of-speech tag reference
- link the CoNLL-2000 IOB chunk tags to the corresponding ACL Anthology paper

## Validation

- the added ACL Anthology link returns HTTP 200
- parsed `chunker.xml` with DTD processing enabled and external resolution disabled
- `mvn -pl opennlp-docs -P!doc-manual-html,!doc-manual-pdf -DskipTests package`