### PR TITLE
OPENNLP-1742: Use the MaxEnt training default for NameFinderME

### DIFF
--- a/opennlp-core/opennlp-cli/src/test/java/opennlp/tools/cmdline/TokenNameFinderToolTest.java
+++ b/opennlp-core/opennlp-cli/src/test/java/opennlp/tools/cmdline/TokenNameFinderToolTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import opennlp.tools.cmdline.namefind.TokenNameFinderTool;
+import opennlp.tools.ml.AlgorithmType;
 import opennlp.tools.namefind.NameFinderME;
 import opennlp.tools.namefind.NameSample;
 import opennlp.tools.namefind.NameSampleDataStream;
@@ -128,6 +129,8 @@ public class TokenNameFinderToolTest {
             StandardCharsets.ISO_8859_1);
 
     TrainingParameters params = new TrainingParameters();
+    // This test verifies CLI output, so keep its fixture independent of the default trainer.
+    params.put(Parameters.ALGORITHM_PARAM, AlgorithmType.PERCEPTRON.getAlgorithmType());
     params.put(Parameters.ITERATIONS_PARAM, 70);
     params.put(Parameters.CUTOFF_PARAM, 1);
 

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/namefind/NameFinderME.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/namefind/NameFinderME.java
@@ -28,7 +28,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import opennlp.tools.commons.ThreadSafe;
-import opennlp.tools.ml.AlgorithmType;
 import opennlp.tools.ml.BeamSearch;
 import opennlp.tools.ml.EventModelSequenceTrainer;
 import opennlp.tools.ml.EventTrainer;
@@ -273,8 +272,7 @@ public class NameFinderME implements TokenNameFinder, Probabilistic {
                                            ObjectStream<NameSample> samples, TrainingParameters params,
                                            TokenNameFinderFactory factory) throws IOException {
 
-    //FIXME OPENNLP-1742
-    params.putIfAbsent(Parameters.ALGORITHM_PARAM, AlgorithmType.PERCEPTRON.getAlgorithmType());
+    params.putIfAbsent(Parameters.ALGORITHM_PARAM, Parameters.ALGORITHM_DEFAULT_VALUE);
     params.putIfAbsent(Parameters.CUTOFF_PARAM, 0);
     params.putIfAbsent(Parameters.ITERATIONS_PARAM, 300);
 

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/namefind/NameFinderMETest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/namefind/NameFinderMETest.java
@@ -76,6 +76,9 @@ public class NameFinderMETest extends AbstractNameFinderTest {
     TokenNameFinderModel nameFinderModel = NameFinderME.train("eng", null, sampleStream,
         params, TokenNameFinderFactory.create(null, null, Collections.emptyMap(), new BioCodec()));
 
+    assertEquals(Parameters.ALGORITHM_DEFAULT_VALUE,
+        params.getStringParameter(Parameters.ALGORITHM_PARAM, null));
+
     TokenNameFinder nameFinder = new NameFinderME(nameFinderModel);
 
     // now test if it can detect the sample sentences

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/namefind/NameFinderMEWithDatesTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/namefind/NameFinderMEWithDatesTest.java
@@ -28,7 +28,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import opennlp.tools.ml.AlgorithmType;
+import opennlp.tools.util.Parameters;
 import opennlp.tools.util.Span;
+import opennlp.tools.util.TrainingParameters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -69,11 +72,11 @@ public class NameFinderMEWithDatesTest extends AbstractNameFinderTest {
       downloadVersion15Model("en-ner-date.bin");
       v15ModelEN = new TokenNameFinderModel(Files.newInputStream(
               OPENNLP_DIR.resolve("en-ner-date.bin")));
-      TokenNameFinderModel trainedModelEN = trainModel("eng",
+      TokenNameFinderModel trainedModelEN = trainDateModel("eng",
               "opennlp/tools/namefind/RandomNewsWithGeneratedDates_EN.train");
       assertNotNull(trainedModelEN);
       assertTrue(hasOtherAsOutcome(trainedModelEN));
-      TokenNameFinderModel trainedModelDE = trainModel("deu",
+      TokenNameFinderModel trainedModelDE = trainDateModel("deu",
               "opennlp/tools/namefind/RandomNewsWithGeneratedDates_DE.train");
       assertNotNull(trainedModelDE);
       assertTrue(hasOtherAsOutcome(trainedModelDE));
@@ -82,6 +85,17 @@ public class NameFinderMEWithDatesTest extends AbstractNameFinderTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static TokenNameFinderModel trainDateModel(String languageCode,
+                                                      String trainingFile) throws IOException {
+    TrainingParameters params = new TrainingParameters();
+    // This suite verifies date spans, so keep its established trainer independent of the default.
+    params.put(Parameters.ALGORITHM_PARAM, AlgorithmType.PERCEPTRON.getAlgorithmType());
+    params.put(Parameters.ITERATIONS_PARAM, 150);
+    params.put(Parameters.THREADS_PARAM, 4);
+    params.put(Parameters.CUTOFF_PARAM, 3);
+    return trainModel(languageCode, trainingFile, params);
   }
 
   /**


### PR DESCRIPTION
## Summary

- use the shared MaxEnt algorithm default when `NameFinderME.train` receives no algorithm
- remove the obsolete OPENNLP-1742 FIXME and the now-unused `AlgorithmType` import
- assert the default algorithm in `NameFinderMETest`
- keep tests that verify established model output on their explicit Perceptron fixtures

## Investigation

With the existing date-test parameters, MaxEnt predicts `im März 2024` instead of the annotated `März 2024`. Lowering the cutoff from 3 to 0 also caused two English date cases to disappear, and raising iterations from 150 to 300 did not correct the German boundary. The expected spans are therefore unchanged; tests with fixed semantic or CLI output now declare the trainer they were designed around.

## Validation

- `mvn -pl opennlp-core/opennlp-runtime -am -Dtest=NameFinderMEWithDatesTest,NameFinderMETest test` — 23 tests, 0 failures
- `mvn -pl opennlp-core/opennlp-runtime -am test` — runtime: 1323 tests, 0 failures, 0 errors, 1 skipped
- `mvn -pl opennlp-core/opennlp-cli -am -Dtest=TokenNameFinderToolTest -Dsurefire.failIfNoSpecifiedTests=false test` — 3 tests, 0 failures
- `mvn -pl opennlp-core/opennlp-cli test` after installing reactor dependencies — 37 tests, 0 failures, 0 errors, 1 skipped