### PR TITLE
OPENNLP-244: Document the BioNLP converter

### DIFF
--- a/opennlp-core/opennlp-formats/src/test/java/opennlp/tools/formats/BioNLP2004NameSampleStreamFactoryTest.java
+++ b/opennlp-core/opennlp-formats/src/test/java/opennlp/tools/formats/BioNLP2004NameSampleStreamFactoryTest.java
@@ -17,7 +17,9 @@
 
 package opennlp.tools.formats;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +34,7 @@ import opennlp.tools.util.ObjectStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BioNLP2004NameSampleStreamFactoryTest extends
@@ -84,6 +87,27 @@ public class BioNLP2004NameSampleStreamFactoryTest extends
       assertEquals("protein", sample.getNames()[2].getType());
       assertEquals("protein", sample.getNames()[3].getType());
       assertEquals("cell_type", sample.getNames()[4].getType());
+    }
+  }
+
+  @Test
+  void testConvertManualExample() throws IOException {
+    String input = "IL-2\tB-DNA\n"
+        + "receptor\tI-DNA\n"
+        + "activates\tO\n"
+        + "T\tB-cell_type\n"
+        + "cells\tI-cell_type\n"
+        + ".\tO\n\n";
+    int types = BioNLP2004NameSampleStream.GENERATE_DNA_ENTITIES
+        | BioNLP2004NameSampleStream.GENERATE_CELLTYPE_ENTITIES;
+
+    try (ObjectStream<NameSample> stream = new BioNLP2004NameSampleStream(
+        () -> new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), types)) {
+      NameSample sample = stream.read();
+      assertNotNull(sample);
+      assertEquals("<START:DNA> IL-2 receptor <END> activates "
+          + "<START:cell_type> T cells <END> .", sample.toString());
+      assertNull(stream.read());
     }
   }
 

--- a/opennlp-docs/src/docbkx/corpora.xml
+++ b/opennlp-docs/src/docbkx/corpora.xml
@@ -522,6 +522,80 @@ path: /dev/opennlp/trunk/opennlp-tools/en-ontonotes.bin]]>
 		</section>
 	</section>
 
+	<section xml:id="tools.corpora.bionlp2004">
+		<title>BioNLP/NLPBA 2004</title>
+		<para>
+		The BioNLP/NLPBA 2004 shared task uses biomedical abstracts derived from the GENIA
+		corpus for named entity recognition. It defines five entity types:
+		<literal>DNA</literal>, <literal>RNA</literal>, <literal>protein</literal>,
+		<literal>cell_type</literal>, and <literal>cell_line</literal>. The
+		<link xlink:href="https://aclanthology.org/W04-1213/">shared task paper</link>
+		describes the corpus and annotation task. OpenNLP identifies this input format as
+		<literal>bionlp2004</literal>.
+		</para>
+
+		<section xml:id="tools.corpora.bionlp2004.getting">
+			<title>Getting the data</title>
+			<para>
+			A copy of the original training and evaluation files is available in the
+			<filename>original-data</filename> directory of the
+			<link xlink:href="https://github.com/spyysalo/jnlpba">JNLPBA corpus repository</link>.
+			The corpus is not distributed with OpenNLP. Review the terms supplied with the corpus
+			before using or redistributing it.
+			</para>
+		</section>
+
+		<section xml:id="tools.corpora.bionlp2004.format">
+			<title>Input format</title>
+			<para>
+			The converter reads UTF-8 text with one token and one IOB tag per line, separated by a
+			tab. A blank line ends a sentence. <literal>B-type</literal> starts an entity,
+			<literal>I-type</literal> continues it, and <literal>O</literal> marks a token outside
+			an entity. Lines beginning with <literal>###MEDLINE:</literal> mark document boundaries
+			in the original corpus. For example:
+			</para>
+			<screen>
+<![CDATA[IL-2	B-DNA
+receptor	I-DNA
+activates	O
+T	B-cell_type
+cells	I-cell_type
+.	O
+
+]]>
+			</screen>
+		</section>
+
+		<section xml:id="tools.corpora.bionlp2004.converting">
+			<title>Converting the data</title>
+			<para>
+			Pass the desired entity types to <option>-types</option> as a comma-separated list. The
+			values are case-sensitive and must use the names shown above. This command selects all
+			five types and writes native OpenNLP name finder samples to
+			<filename>jnlpba.train</filename>:
+			</para>
+			<screen>
+<![CDATA[$ opennlp TokenNameFinderConverter bionlp2004 \
+  -data original-data/train/Genia4ERtask1.iob2 \
+  -types DNA,protein,cell_type,cell_line,RNA \
+  > jnlpba.train]]>
+			</screen>
+			<para>
+			The input example from the previous section is converted to:
+			</para>
+			<screen>
+<![CDATA[<START:DNA> IL-2 receptor <END> activates <START:cell_type> T cells <END> .]]>
+			</screen>
+			<para>
+			To convert only a subset, list only those types, for example
+			<literal>-types protein,cell_type</literal>. The resulting file can be passed to the
+			standard <command>TokenNameFinderTrainer</command>. See
+			<xref linkend="tools.namefind.training"/> for training
+			parameters and data recommendations.
+			</para>
+		</section>
+	</section>
+
 	<section xml:id="tools.corpora.brat">
 		<title>Brat Format Support</title>
 		<para>


### PR DESCRIPTION
## Summary

- add a BioNLP/NLPBA 2004 section to the corpora guide
- describe the corpus source, IOB input format, supported entity types, and conversion command
- show the native OpenNLP output and link it to Name Finder training
- add a focused parser test for the example used in the manual

## Validation

- `mvn -pl opennlp-core/opennlp-formats -am -Dtest=BioNLP2004NameSampleStreamFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test` — 6 tests, 0 failures
- `mvn -pl opennlp-core/opennlp-formats test` — 353 tests, 0 failures, 0 errors, 1 skipped
- `mvn -pl opennlp-docs -DskipTests package` — generated HTML, PDF, and FO successfully