### PR TITLE
OPENNLP-1903: Replace per-candidate Sequence copies with chain nodes in BeamSearch

### DIFF
--- a/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/BeamSearch.java
+++ b/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/BeamSearch.java
@@ -18,7 +18,6 @@
 package opennlp.tools.ml;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
 
@@ -76,6 +75,60 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
   }
 
   /**
+   * Immutable chain node used only inside
+   * {@link #bestSequences(int, Object[], Object[], double, BeamSearchContextGenerator, SequenceValidator)}.
+   * Each child links to its parent instead of copying the parent's outcome/probability lists,
+   * so expanding a candidate is O(1); the outcome array is materialized lazily and cached.
+   * Score accumulation ({@code parent.score + StrictMath.log(prob)}) mirrors
+   * {@link Sequence#Sequence(Sequence, String, double)} bit-for-bit, and {@link #compareTo}
+   * mirrors {@link Sequence#compareTo}, so the search is behavior-identical to running the
+   * queues over {@link Sequence} directly.
+   */
+  private static final class SearchNode implements Comparable<SearchNode> {
+    private final SearchNode parent;
+    private final String outcome; // null on the root
+    private final double prob;
+    private final double score;
+    private final int size;
+    private String[] outcomesCache; // lazily built; nodes are never mutated, so the cache stays valid
+
+    private SearchNode() {
+      this.parent = null;
+      this.outcome = null;
+      this.prob = 0d;
+      this.score = 0d;
+      this.size = 0;
+    }
+
+    private SearchNode(SearchNode parent, String outcome, double prob) {
+      this.parent = parent;
+      this.outcome = outcome;
+      this.prob = prob;
+      this.score = parent.score + StrictMath.log(prob);
+      this.size = parent.size + 1;
+    }
+
+    private String[] outcomes() {
+      String[] cached = outcomesCache;
+      if (cached == null) {
+        cached = new String[size];
+        SearchNode node = this;
+        for (int i = size - 1; i >= 0; i--) {
+          cached[i] = node.outcome;
+          node = node.parent;
+        }
+        outcomesCache = cached;
+      }
+      return cached;
+    }
+
+    @Override
+    public int compareTo(SearchNode other) {
+      return Double.compare(other.score, this.score);
+    }
+  }
+
+  /**
    * Initializes a {@link BeamSearch} instance.
    *
    * @param size The size of the beam (k).
@@ -113,10 +166,10 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
 
     final CacheState state = threadState.get();
 
-    Queue<Sequence> prev = new PriorityQueue<>(size);
-    Queue<Sequence> next = new PriorityQueue<>(size);
-    Queue<Sequence> tmp;
-    prev.add(new Sequence());
+    Queue<SearchNode> prev = new PriorityQueue<>(size);
+    Queue<SearchNode> next = new PriorityQueue<>(size);
+    Queue<SearchNode> tmp;
+    prev.add(new SearchNode());
 
     Object[] context = additionalContext;
     if (context == null) {
@@ -127,9 +180,8 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
       final int sz = StrictMath.min(size, prev.size());
 
       for (int sc = 0; prev.size() > 0 && sc < sz; sc++) {
-        final Sequence top = prev.remove();
-        final List<String> tmpOutcomes = top.getOutcomes();
-        final String[] outcomes = tmpOutcomes.toArray(new String[0]);
+        final SearchNode top = prev.remove();
+        final String[] outcomes = top.outcomes();
         final String[] contexts = cg.getContext(i, sequence, outcomes, context);
         final double[] scores;
         if (state.cache != null) {
@@ -157,8 +209,8 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
           if (scores[p] >= min) {
             final String out = model.getOutcome(p);
             if (validator.validSequence(i, sequence, outcomes, out)) {
-              final Sequence ns = new Sequence(top, out, scores[p]);
-              if (ns.getScore() > minSequenceScore) {
+              final SearchNode ns = new SearchNode(top, out, scores[p]);
+              if (ns.score > minSequenceScore) {
                 next.add(ns);
               }
             }
@@ -169,8 +221,8 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
           for (int p = 0; p < scores.length; p++) {
             final String out = model.getOutcome(p);
             if (validator.validSequence(i, sequence, outcomes, out)) {
-              final Sequence ns = new Sequence(top, out, scores[p]);
-              if (ns.getScore() > minSequenceScore) {
+              final SearchNode ns = new SearchNode(top, out, scores[p]);
+              if (ns.score > minSequenceScore) {
                 next.add(ns);
               }
             }
@@ -189,7 +241,22 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
     final Sequence[] topSequences = new Sequence[numSeq];
 
     for (int seqIndex = 0; seqIndex < numSeq; seqIndex++) {
-      topSequences[seqIndex] = prev.remove();
+      final SearchNode winner = prev.remove();
+      final String[] outs = new String[winner.size];
+      final double[] probs = new double[winner.size];
+      SearchNode node = winner;
+      for (int j = winner.size - 1; j >= 0; j--) {
+        outs[j] = node.outcome;
+        probs[j] = node.prob;
+        node = node.parent;
+      }
+      // Sequence.add accumulates score += StrictMath.log(p) in the same order as the chain,
+      // so the rebuilt Sequence is bit-identical to one built directly during the search.
+      final Sequence seq = new Sequence();
+      for (int j = 0; j < outs.length; j++) {
+        seq.add(outs[j], probs[j]);
+      }
+      topSequences[seqIndex] = seq;
     }
 
     return topSequences;

--- a/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/BeamSearch.java
+++ b/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/BeamSearch.java
@@ -75,14 +75,14 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
   }
 
   /**
-   * Immutable chain node used only inside
+   * Immutable node in a backward-linked chain of outcome candidates, used only inside
    * {@link #bestSequences(int, Object[], Object[], double, BeamSearchContextGenerator, SequenceValidator)}.
-   * Each child links to its parent instead of copying the parent's outcome/probability lists,
-   * so expanding a candidate is O(1); the outcome array is materialized lazily and cached.
-   * Score accumulation ({@code parent.score + StrictMath.log(prob)}) mirrors
-   * {@link Sequence#Sequence(Sequence, String, double)} bit-for-bit, and {@link #compareTo}
-   * mirrors {@link Sequence#compareTo}, so the search is behavior-identical to running the
-   * queues over {@link Sequence} directly.
+   * A node stores its own outcome plus a parent link, so extending a candidate is O(1);
+   * the full outcome array is materialized only when a candidate is expanded.
+   * Score accumulation ({@code parent.score + StrictMath.log(prob)}) and
+   * {@link #compareTo(SearchNode)} must stay in lockstep with
+   * {@link Sequence#Sequence(Sequence, String, double)} and {@link Sequence#compareTo(Sequence)}
+   * to keep search results bit-identical to a search over {@link Sequence} instances.
    */
   private static final class SearchNode implements Comparable<SearchNode> {
     private final SearchNode parent;
@@ -90,8 +90,10 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
     private final double prob;
     private final double score;
     private final int size;
-    private String[] outcomesCache; // lazily built; nodes are never mutated, so the cache stays valid
 
+    /**
+     * Creates the root node: the empty candidate with score {@code 0}.
+     */
     private SearchNode() {
       this.parent = null;
       this.outcome = null;
@@ -100,6 +102,13 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
       this.size = 0;
     }
 
+    /**
+     * Creates a candidate extending {@code parent} by one outcome.
+     *
+     * @param parent The candidate to extend. Must not be {@code null}.
+     * @param outcome The outcome to append.
+     * @param prob The probability of {@code outcome}.
+     */
     private SearchNode(SearchNode parent, String outcome, double prob) {
       this.parent = parent;
       this.outcome = outcome;
@@ -108,20 +117,22 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
       this.size = parent.size + 1;
     }
 
+    /**
+     * @return The outcomes on the path from the root to this node, in sequence order.
+     */
     private String[] outcomes() {
-      String[] cached = outcomesCache;
-      if (cached == null) {
-        cached = new String[size];
-        SearchNode node = this;
-        for (int i = size - 1; i >= 0; i--) {
-          cached[i] = node.outcome;
-          node = node.parent;
-        }
-        outcomesCache = cached;
+      final String[] outcomes = new String[size];
+      SearchNode node = this;
+      for (int i = size - 1; i >= 0; i--) {
+        outcomes[i] = node.outcome;
+        node = node.parent;
       }
-      return cached;
+      return outcomes;
     }
 
+    /**
+     * Orders nodes by descending score, mirroring {@link Sequence#compareTo(Sequence)}.
+     */
     @Override
     public int compareTo(SearchNode other) {
       return Double.compare(other.score, this.score);
@@ -250,8 +261,8 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
         probs[j] = node.prob;
         node = node.parent;
       }
-      // Sequence.add accumulates score += StrictMath.log(p) in the same order as the chain,
-      // so the rebuilt Sequence is bit-identical to one built directly during the search.
+      // Sequence.add accumulates score += StrictMath.log(p) per element, so rebuilding in
+      // chain order yields a score bit-identical to the node's accumulated score.
       final Sequence seq = new Sequence();
       for (int j = 0; j < outs.length; j++) {
         seq.add(outs[j], probs[j]);

--- a/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/BeamSearch.java
+++ b/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/BeamSearch.java
@@ -79,10 +79,13 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
    * {@link #bestSequences(int, Object[], Object[], double, BeamSearchContextGenerator, SequenceValidator)}.
    * A node stores its own outcome plus a parent link, so extending a candidate is O(1);
    * the full outcome array is materialized only when a candidate is expanded.
-   * Score accumulation ({@code parent.score + StrictMath.log(prob)}) and
-   * {@link #compareTo(SearchNode)} must stay in lockstep with
-   * {@link Sequence#Sequence(Sequence, String, double)} and {@link Sequence#compareTo(Sequence)}
-   * to keep search results bit-identical to a search over {@link Sequence} instances.
+   * Score accumulation ({@code parent.score + StrictMath.log(prob)}) mirrors
+   * {@link Sequence#Sequence(Sequence, String, double)}, and descending score order
+   * mirrors {@link Sequence#compareTo(Sequence)}, so non-tied search results stay
+   * bit-identical to a search over {@link Sequence} instances. Unlike
+   * {@link Sequence#compareTo(Sequence)}, {@link #compareTo(SearchNode)} additionally
+   * resolves exact score ties into a canonical outcome order; under ties the
+   * {@link Sequence}-based search has no defined order at all.
    */
   private static final class SearchNode implements Comparable<SearchNode> {
     private final SearchNode parent;
@@ -132,10 +135,28 @@ public class BeamSearch implements SequenceClassificationModel, AutoCloseable {
 
     /**
      * Orders nodes by descending score, mirroring {@link Sequence#compareTo(Sequence)}.
+     * Exact score ties are broken lexicographically by the outcome chain from the
+     * root, so tied candidates expand and are returned in the same canonical order
+     * on every run and JVM. {@link PriorityQueue} gives no ordering guarantee for
+     * elements whose comparison returns {@code 0}, and ties decide both which
+     * candidates survive beam truncation and the order of equal-scored winners.
      */
     @Override
     public int compareTo(SearchNode other) {
-      return Double.compare(other.score, this.score);
+      final int byScore = Double.compare(other.score, this.score);
+      if (byScore != 0) {
+        return byScore;
+      }
+      final String[] mine = outcomes();
+      final String[] theirs = other.outcomes();
+      final int common = StrictMath.min(mine.length, theirs.length);
+      for (int i = 0; i < common; i++) {
+        final int byOutcome = mine[i].compareTo(theirs[i]);
+        if (byOutcome != 0) {
+          return byOutcome;
+        }
+      }
+      return Integer.compare(mine.length, theirs.length);
     }
   }
 

--- a/opennlp-core/opennlp-runtime/BENCHMARKS.md
+++ b/opennlp-core/opennlp-runtime/BENCHMARKS.md
@@ -15,6 +15,7 @@ variance reporting.
 | `POSTaggerMEBenchmark` | POSTaggerME | 3 approaches x 2 cache configs |
 | `SnowballStemmerBenchmark` | SnowballStemmer | 3 approaches (incl. plain-field baseline) |
 | `CachingStemmerBenchmark` | CachingStemmer | cached vs uncached x 2 workloads |
+| `BeamSearchBenchmark` | BeamSearch | 3 sequence lengths x 2 cache configs, 1 vs max threads |
 
 ### Approaches measured
 
@@ -120,6 +121,52 @@ The `POSTaggerMEBenchmark` uses `@Param({"0", "3"})` for cache
 size, producing a matrix of 3 approaches x 2 cache configs = 6
 benchmark runs. This quantifies whether the context generator
 cache provides measurable benefit.
+
+### BeamSearch results
+
+`BeamSearchBenchmark` decodes synthetic token sequences with a shared
+`BeamSearch` (beam size 3, deterministic hash-seeded model, accept-all
+validator). One op = one `bestSequence` call; invocations rotate through a
+pool of 64 seeded inputs. The `sequenceLength` param (8/64/256) is the key
+axis: the O(n^2) per-candidate outcome-list copying that the chain-node
+refactor eliminated only shows up on long sequences (NER chunks run 200+
+tokens). The `cacheSize` param (0/64) toggles the contexts cache. To produce
+the pre-refactor baseline, swap the pre-refactor `opennlp-ml-commons` jar
+onto the classpath ahead of the freshly built classes — the benchmark only
+uses the unchanged public API — and rerun.
+
+Results (Linux, JDK 25, 24 pinned cores of a 32-core box, 2 forks x 10
+iterations; ops/s = decoded sequences per second):
+
+| Method | sequenceLength | cacheSize | 1 thread | 24 threads | scaling |
+|--------|---------------:|----------:|---------:|-----------:|--------:|
+| pre-refactor  | 8   | 0  | 226,337 ± 4,164  | 1,404,404 ± 67,614 | 6.2x |
+| pre-refactor  | 64  | 0  | 17,802 ± 43      | 67,482 ± 817       | 3.8x |
+| pre-refactor  | 256 | 0  | 2,236 ± 38       | 5,491 ± 26         | 2.5x |
+| pre-refactor  | 8   | 64 | 234,592 ± 705    | 1,382,812 ± 72,577 | 5.9x |
+| pre-refactor  | 64  | 64 | 17,968 ± 92      | 61,639 ± 2,726     | 3.4x |
+| pre-refactor  | 256 | 64 | 2,224 ± 20       | 5,260 ± 92         | 2.4x |
+| post-refactor | 8   | 0  | 450,384 ± 3,306  | 3,162,724 ± 495,301 | 7.0x |
+| post-refactor | 64  | 0  | 33,936 ± 482     | 297,001 ± 13,049   | 8.8x |
+| post-refactor | 256 | 0  | 4,357 ± 168      | 50,176 ± 307       | 11.5x |
+| post-refactor | 8   | 64 | 488,155 ± 8,095  | 3,512,519 ± 7,541  | 7.2x |
+| post-refactor | 64  | 64 | 34,818 ± 232     | 347,266 ± 942      | 10.0x |
+| post-refactor | 256 | 64 | 4,308 ± 27       | 50,203 ± 230       | 11.7x |
+
+Two readings. First, the refactor's win grows with sequence length —
+~2x single-thread at every length, and at 24 threads 2.3x (len 8),
+4.4x (len 64), and 9.1x (len 256) — the signature of an O(n^2) copy
+cost being removed. Second, the pre-refactor scaling collapses as
+sequences lengthen (6.2x down to 2.5x on 24 threads: memory-write
+saturation from per-candidate list copying), while post-refactor
+scaling grows with length (7.0x up to 11.5x).
+
+Note the synthetic model's `eval` is a cheap hash, so this isolates
+the sequence-mechanics cost the refactor targets; with a real maxent
+model the eval compute is shared by both versions and the relative
+single-thread win is smaller (~1.3x on ARM, roughly neutral on x86),
+while the concurrent scaling gap is preserved (measured 5.8x -> 13.3x
+at saturation on 24 pinned cores with a real NER model).
 
 ## JUnit Correctness Test
 

--- a/opennlp-core/opennlp-runtime/BENCHMARKS.md
+++ b/opennlp-core/opennlp-runtime/BENCHMARKS.md
@@ -129,11 +129,12 @@ cache provides measurable benefit.
 validator). One op = one `bestSequence` call; invocations rotate through a
 pool of 64 seeded inputs. The `sequenceLength` param (8/64/256) is the key
 axis: the O(n^2) per-candidate outcome-list copying that the chain-node
-refactor eliminated only shows up on long sequences (NER chunks run 200+
-tokens). The `cacheSize` param (0/64) toggles the contexts cache. To produce
-the pre-refactor baseline, swap the pre-refactor `opennlp-ml-commons` jar
-onto the classpath ahead of the freshly built classes — the benchmark only
-uses the unchanged public API — and rerun.
+refactor (OPENNLP-1903) eliminated only shows up on long sequences (NER
+chunks run 200+ tokens). The `cacheSize` param (0/64) toggles the contexts
+cache. To produce the pre-refactor baseline, place an `opennlp-ml-commons`
+jar built before OPENNLP-1903 on the classpath ahead of the freshly built
+classes and rerun; the benchmark only uses public API that predates the
+refactor.
 
 Results (Linux, JDK 25, 24 pinned cores of a 32-core box, 2 forks x 10
 iterations; ops/s = decoded sequences per second):
@@ -153,9 +154,9 @@ iterations; ops/s = decoded sequences per second):
 | post-refactor | 64  | 64 | 34,818 ± 232     | 347,266 ± 942      | 10.0x |
 | post-refactor | 256 | 64 | 4,308 ± 27       | 50,203 ± 230       | 11.7x |
 
-Two readings. First, the refactor's win grows with sequence length —
+Two readings. First, the refactor's win grows with sequence length:
 ~2x single-thread at every length, and at 24 threads 2.3x (len 8),
-4.4x (len 64), and 9.1x (len 256) — the signature of an O(n^2) copy
+4.4x (len 64), and 9.1x (len 256), the signature of an O(n^2) copy
 cost being removed. Second, the pre-refactor scaling collapses as
 sequences lengthen (6.2x down to 2.5x on 24 threads: memory-write
 saturation from per-candidate list copying), while post-refactor
@@ -166,7 +167,8 @@ the sequence-mechanics cost the refactor targets; with a real maxent
 model the eval compute is shared by both versions and the relative
 single-thread win is smaller (~1.3x on ARM, roughly neutral on x86),
 while the concurrent scaling gap is preserved (measured 5.8x -> 13.3x
-at saturation on 24 pinned cores with a real NER model).
+at saturation on 24 pinned cores with the SourceForge-era 1.5 English
+`en-ner-person.bin` model).
 
 ## JUnit Correctness Test
 

--- a/opennlp-core/opennlp-runtime/BENCHMARKS.md
+++ b/opennlp-core/opennlp-runtime/BENCHMARKS.md
@@ -15,7 +15,6 @@ variance reporting.
 | `POSTaggerMEBenchmark` | POSTaggerME | 3 approaches x 2 cache configs |
 | `SnowballStemmerBenchmark` | SnowballStemmer | 3 approaches (incl. plain-field baseline) |
 | `CachingStemmerBenchmark` | CachingStemmer | cached vs uncached x 2 workloads |
-| `BeamSearchBenchmark` | BeamSearch | 3 sequence lengths x 2 cache configs, 1 vs max threads |
 
 ### Approaches measured
 
@@ -121,54 +120,6 @@ The `POSTaggerMEBenchmark` uses `@Param({"0", "3"})` for cache
 size, producing a matrix of 3 approaches x 2 cache configs = 6
 benchmark runs. This quantifies whether the context generator
 cache provides measurable benefit.
-
-### BeamSearch results
-
-`BeamSearchBenchmark` decodes synthetic token sequences with a shared
-`BeamSearch` (beam size 3, deterministic hash-seeded model, accept-all
-validator). One op = one `bestSequence` call; invocations rotate through a
-pool of 64 seeded inputs. The `sequenceLength` param (8/64/256) is the key
-axis: the O(n^2) per-candidate outcome-list copying that the chain-node
-refactor (OPENNLP-1903) eliminated only shows up on long sequences (NER
-chunks run 200+ tokens). The `cacheSize` param (0/64) toggles the contexts
-cache. To produce the pre-refactor baseline, place an `opennlp-ml-commons`
-jar built before OPENNLP-1903 on the classpath ahead of the freshly built
-classes and rerun; the benchmark only uses public API that predates the
-refactor.
-
-Results (Linux, JDK 25, 24 pinned cores of a 32-core box, 2 forks x 10
-iterations; ops/s = decoded sequences per second):
-
-| Method | sequenceLength | cacheSize | 1 thread | 24 threads | scaling |
-|--------|---------------:|----------:|---------:|-----------:|--------:|
-| pre-refactor  | 8   | 0  | 226,337 ± 4,164  | 1,404,404 ± 67,614 | 6.2x |
-| pre-refactor  | 64  | 0  | 17,802 ± 43      | 67,482 ± 817       | 3.8x |
-| pre-refactor  | 256 | 0  | 2,236 ± 38       | 5,491 ± 26         | 2.5x |
-| pre-refactor  | 8   | 64 | 234,592 ± 705    | 1,382,812 ± 72,577 | 5.9x |
-| pre-refactor  | 64  | 64 | 17,968 ± 92      | 61,639 ± 2,726     | 3.4x |
-| pre-refactor  | 256 | 64 | 2,224 ± 20       | 5,260 ± 92         | 2.4x |
-| post-refactor | 8   | 0  | 450,384 ± 3,306  | 3,162,724 ± 495,301 | 7.0x |
-| post-refactor | 64  | 0  | 33,936 ± 482     | 297,001 ± 13,049   | 8.8x |
-| post-refactor | 256 | 0  | 4,357 ± 168      | 50,176 ± 307       | 11.5x |
-| post-refactor | 8   | 64 | 488,155 ± 8,095  | 3,512,519 ± 7,541  | 7.2x |
-| post-refactor | 64  | 64 | 34,818 ± 232     | 347,266 ± 942      | 10.0x |
-| post-refactor | 256 | 64 | 4,308 ± 27       | 50,203 ± 230       | 11.7x |
-
-Two readings. First, the refactor's win grows with sequence length:
-~2x single-thread at every length, and at 24 threads 2.3x (len 8),
-4.4x (len 64), and 9.1x (len 256), the signature of an O(n^2) copy
-cost being removed. Second, the pre-refactor scaling collapses as
-sequences lengthen (6.2x down to 2.5x on 24 threads: memory-write
-saturation from per-candidate list copying), while post-refactor
-scaling grows with length (7.0x up to 11.5x).
-
-Note the synthetic model's `eval` is a cheap hash, so this isolates
-the sequence-mechanics cost the refactor targets; with a real maxent
-model the eval compute is shared by both versions and the relative
-single-thread win is smaller (~1.3x on ARM, roughly neutral on x86),
-while the concurrent scaling gap is preserved (measured 5.8x -> 13.3x
-at saturation on 24 pinned cores with the SourceForge-era 1.5 English
-`en-ner-person.bin` model).
 
 ## JUnit Correctness Test
 

--- a/opennlp-core/opennlp-runtime/src/jmh/java/opennlp/tools/ml/BeamSearchBenchmark.java
+++ b/opennlp-core/opennlp-runtime/src/jmh/java/opennlp/tools/ml/BeamSearchBenchmark.java
@@ -41,7 +41,6 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-import opennlp.tools.ml.model.MaxentModel;
 import opennlp.tools.util.BeamSearchContextGenerator;
 import opennlp.tools.util.SequenceValidator;
 
@@ -49,15 +48,15 @@ import opennlp.tools.util.SequenceValidator;
  * JMH benchmark for {@link BeamSearch} on long input sequences.
  * <p>
  * One op = one {@code bestSequence} call on a synthetic token sequence of
- * {@code sequenceLength} tokens. Long sequences are what expose the O(n^2)
- * per-candidate outcome-list copying that the chain-node refactor eliminated;
- * the 5-10 token sentences used by the ME benchmarks would show nothing.
- * Only the pre-refactor public API is used
+ * {@code sequenceLength} tokens. Long sequences are what expose the quadratic
+ * per-candidate outcome-list copying removed with OPENNLP-1903; sentences of
+ * 5-10 tokens, as used by the ME benchmarks, show no measurable difference.
+ * Only public API that predates OPENNLP-1903 is used
  * ({@code BeamSearch(int, MaxentModel, int)} and
  * {@code bestSequence(T[], Object[], BeamSearchContextGenerator, SequenceValidator)}),
- * so the same compiled class exercises both implementations: to produce the
- * baseline, swap the pre-refactor {@code opennlp-ml-commons} jar onto the
- * classpath ahead of the freshly built classes and rerun.
+ * so the same compiled class exercises both implementations: to produce a
+ * baseline, place an {@code opennlp-ml-commons} jar built before OPENNLP-1903
+ * on the classpath ahead of the freshly built classes and rerun.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -69,7 +68,9 @@ public class BeamSearchBenchmark {
   private static final int BEAM_SIZE = 3;
   private static final int NUM_INPUTS = 64;
   private static final int VOCAB_SIZE = 17;
-  private static final long INPUT_SEED = 0x5eedL;
+  /** Seed for both the input generator and the {@link SeededMaxentModel}. */
+  private static final long SEED = 0x5eedL;
+  private static final String[] MODEL_OUTCOMES = {"start", "cont", "other"};
 
   private static final SequenceValidator<String> ACCEPT_ALL =
       (i, input, outcomes, outcome) -> true;
@@ -90,10 +91,11 @@ public class BeamSearchBenchmark {
 
     @Setup(Level.Trial)
     public void create() {
-      beamSearch = new BeamSearch(BEAM_SIZE, new SeededModel(), cacheSize);
+      beamSearch = new BeamSearch(BEAM_SIZE,
+          new SeededMaxentModel(MODEL_OUTCOMES, SEED), cacheSize);
       contextGenerator = new TokenContextGenerator();
       inputs = new String[NUM_INPUTS][];
-      Random rnd = new Random(INPUT_SEED);
+      Random rnd = new Random(SEED);
       for (int n = 0; n < NUM_INPUTS; n++) {
         String[] input = new String[sequenceLength];
         for (int i = 0; i < sequenceLength; i++) {
@@ -107,87 +109,6 @@ public class BeamSearchBenchmark {
       // Rotate through the input pool so repeated invocations decode different
       // sequences instead of hammering one fully cache-warm input.
       return inputs[Math.floorMod(cursor.getAndIncrement(), NUM_INPUTS)];
-    }
-  }
-
-  /**
-   * A deterministic pseudo-random {@link MaxentModel}: the probability for an
-   * outcome is derived from a hash of the joined context strings with
-   * splitmix64-style mixing, so repeated evals of the same context return
-   * identical values in (0.01, 0.99]. Values are intentionally not normalized.
-   * The buffer contract is honored: {@code eval(context, probs)} writes into
-   * the passed array and returns that same array.
-   */
-  static final class SeededModel implements MaxentModel {
-
-    private final String[] outcomes = {"start", "cont", "other"};
-
-    private double prob(String[] context, int outcomeIndex) {
-      long h = 0x5eedL;
-      for (String c : context) {
-        h = mix(h, c.hashCode());
-      }
-      h = mix(h, outcomeIndex);
-      // splitmix64 finalizer for avalanche
-      h ^= h >>> 30;
-      h *= 0xBF58476D1CE4E5B9L;
-      h ^= h >>> 27;
-      h *= 0x94D049BB133111EBL;
-      h ^= h >>> 31;
-      double u = (h >>> 11) * (1.0 / (1L << 53)); // [0, 1)
-      return 0.01 + 0.98 * u; // (0.01, 0.99]
-    }
-
-    private static long mix(long h, long v) {
-      return (h ^ (v + 0x9E3779B97F4A7C15L)) * 0x100000001B3L;
-    }
-
-    @Override
-    public double[] eval(String[] context) {
-      return eval(context, new double[outcomes.length]);
-    }
-
-    @Override
-    public double[] eval(String[] context, double[] probs) {
-      for (int i = 0; i < outcomes.length; i++) {
-        probs[i] = prob(context, i);
-      }
-      return probs; // buffer contract: write into the passed array AND return it
-    }
-
-    @Override
-    public double[] eval(String[] context, float[] values) {
-      return eval(context);
-    }
-
-    @Override
-    public String getOutcome(int i) {
-      return outcomes[i];
-    }
-
-    @Override
-    public int getNumOutcomes() {
-      return outcomes.length;
-    }
-
-    @Override
-    public String getAllOutcomes(double[] outcomes) {
-      return null;
-    }
-
-    @Override
-    public String getBestOutcome(double[] outcomes) {
-      return null;
-    }
-
-    @Override
-    public int getIndex(String outcome) {
-      for (int i = 0; i < outcomes.length; i++) {
-        if (outcomes[i].equals(outcome)) {
-          return i;
-        }
-      }
-      return -1;
     }
   }
 

--- a/opennlp-core/opennlp-runtime/src/jmh/java/opennlp/tools/ml/BeamSearchBenchmark.java
+++ b/opennlp-core/opennlp-runtime/src/jmh/java/opennlp/tools/ml/BeamSearchBenchmark.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.ml;
+
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import opennlp.tools.ml.model.MaxentModel;
+import opennlp.tools.util.BeamSearchContextGenerator;
+import opennlp.tools.util.SequenceValidator;
+
+/**
+ * JMH benchmark for {@link BeamSearch} on long input sequences.
+ * <p>
+ * One op = one {@code bestSequence} call on a synthetic token sequence of
+ * {@code sequenceLength} tokens. Long sequences are what expose the O(n^2)
+ * per-candidate outcome-list copying that the chain-node refactor eliminated;
+ * the 5-10 token sentences used by the ME benchmarks would show nothing.
+ * Only the pre-refactor public API is used
+ * ({@code BeamSearch(int, MaxentModel, int)} and
+ * {@code bestSequence(T[], Object[], BeamSearchContextGenerator, SequenceValidator)}),
+ * so the same compiled class exercises both implementations: to produce the
+ * baseline, swap the pre-refactor {@code opennlp-ml-commons} jar onto the
+ * classpath ahead of the freshly built classes and rerun.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 10, time = 2)
+@Fork(2)
+public class BeamSearchBenchmark {
+
+  private static final int BEAM_SIZE = 3;
+  private static final int NUM_INPUTS = 64;
+  private static final int VOCAB_SIZE = 17;
+  private static final long INPUT_SEED = 0x5eedL;
+
+  private static final SequenceValidator<String> ACCEPT_ALL =
+      (i, input, outcomes, outcome) -> true;
+
+  @State(Scope.Benchmark)
+  public static class SearchState {
+
+    @Param({"8", "64", "256"})
+    int sequenceLength;
+
+    @Param({"0", "64"})
+    int cacheSize;
+
+    BeamSearch beamSearch;
+    TokenContextGenerator contextGenerator;
+    String[][] inputs;
+    final AtomicInteger cursor = new AtomicInteger();
+
+    @Setup(Level.Trial)
+    public void create() {
+      beamSearch = new BeamSearch(BEAM_SIZE, new SeededModel(), cacheSize);
+      contextGenerator = new TokenContextGenerator();
+      inputs = new String[NUM_INPUTS][];
+      Random rnd = new Random(INPUT_SEED);
+      for (int n = 0; n < NUM_INPUTS; n++) {
+        String[] input = new String[sequenceLength];
+        for (int i = 0; i < sequenceLength; i++) {
+          input[i] = "t" + rnd.nextInt(VOCAB_SIZE);
+        }
+        inputs[n] = input;
+      }
+    }
+
+    String[] nextInput() {
+      // Rotate through the input pool so repeated invocations decode different
+      // sequences instead of hammering one fully cache-warm input.
+      return inputs[Math.floorMod(cursor.getAndIncrement(), NUM_INPUTS)];
+    }
+  }
+
+  /**
+   * A deterministic pseudo-random {@link MaxentModel}: the probability for an
+   * outcome is derived from a hash of the joined context strings with
+   * splitmix64-style mixing, so repeated evals of the same context return
+   * identical values in (0.01, 0.99]. Values are intentionally not normalized.
+   * The buffer contract is honored: {@code eval(context, probs)} writes into
+   * the passed array and returns that same array.
+   */
+  static final class SeededModel implements MaxentModel {
+
+    private final String[] outcomes = {"start", "cont", "other"};
+
+    private double prob(String[] context, int outcomeIndex) {
+      long h = 0x5eedL;
+      for (String c : context) {
+        h = mix(h, c.hashCode());
+      }
+      h = mix(h, outcomeIndex);
+      // splitmix64 finalizer for avalanche
+      h ^= h >>> 30;
+      h *= 0xBF58476D1CE4E5B9L;
+      h ^= h >>> 27;
+      h *= 0x94D049BB133111EBL;
+      h ^= h >>> 31;
+      double u = (h >>> 11) * (1.0 / (1L << 53)); // [0, 1)
+      return 0.01 + 0.98 * u; // (0.01, 0.99]
+    }
+
+    private static long mix(long h, long v) {
+      return (h ^ (v + 0x9E3779B97F4A7C15L)) * 0x100000001B3L;
+    }
+
+    @Override
+    public double[] eval(String[] context) {
+      return eval(context, new double[outcomes.length]);
+    }
+
+    @Override
+    public double[] eval(String[] context, double[] probs) {
+      for (int i = 0; i < outcomes.length; i++) {
+        probs[i] = prob(context, i);
+      }
+      return probs; // buffer contract: write into the passed array AND return it
+    }
+
+    @Override
+    public double[] eval(String[] context, float[] values) {
+      return eval(context);
+    }
+
+    @Override
+    public String getOutcome(int i) {
+      return outcomes[i];
+    }
+
+    @Override
+    public int getNumOutcomes() {
+      return outcomes.length;
+    }
+
+    @Override
+    public String getAllOutcomes(double[] outcomes) {
+      return null;
+    }
+
+    @Override
+    public String getBestOutcome(double[] outcomes) {
+      return null;
+    }
+
+    @Override
+    public int getIndex(String outcome) {
+      for (int i = 0; i < outcomes.length; i++) {
+        if (outcomes[i].equals(outcome)) {
+          return i;
+        }
+      }
+      return -1;
+    }
+  }
+
+  /**
+   * Derives contexts from the current token and the previous outcome, interned
+   * so identical context content maps to the same {@code String[]} instance
+   * and the identity-keyed contexts cache in {@link BeamSearch} produces hits.
+   * Thread-safe.
+   */
+  static final class TokenContextGenerator implements BeamSearchContextGenerator<String> {
+
+    private final ConcurrentHashMap<String, String[]> intern = new ConcurrentHashMap<>();
+
+    @Override
+    public String[] getContext(int index, String[] sequence,
+                               String[] priorDecisions, Object[] additionalContext) {
+      String prev = index > 0 ? priorDecisions[index - 1] : "<s>";
+      String[] ctx = {"tok=" + sequence[index], "prev=" + prev};
+      String key = ctx[0] + '|' + ctx[1];
+      String[] existing = intern.putIfAbsent(key, ctx);
+      return existing != null ? existing : ctx;
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void bestSequenceSingle(SearchState state, Blackhole bh) {
+    bh.consume(state.beamSearch.bestSequence(state.nextInput(), null,
+        state.contextGenerator, ACCEPT_ALL));
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void bestSequenceConcurrent(SearchState state, Blackhole bh) {
+    bh.consume(state.beamSearch.bestSequence(state.nextInput(), null,
+        state.contextGenerator, ACCEPT_ALL));
+  }
+
+  /**
+   * Quick local iteration only: {@code forks(0)} disables JVM fork isolation
+   * (unlike {@code mvn} with the {@code jmh} profile).
+   * Use the Maven-invoked configuration for publishable numbers.
+   */
+  public static void main(String[] args) throws Exception {
+    Options opt = new OptionsBuilder()
+        .include(BeamSearchBenchmark.class.getSimpleName())
+        .forks(0)
+        .warmupIterations(1)
+        .warmupTime(TimeValue.seconds(1))
+        .measurementIterations(1)
+        .measurementTime(TimeValue.seconds(1))
+        .build();
+    new Runner(opt).run();
+  }
+}

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/BeamSearchEquivalenceTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/BeamSearchEquivalenceTest.java
@@ -1,0 +1,647 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.ml;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import opennlp.tools.ml.model.MaxentModel;
+import opennlp.tools.util.BeamSearchContextGenerator;
+import opennlp.tools.util.Cache;
+import opennlp.tools.util.Sequence;
+import opennlp.tools.util.SequenceValidator;
+
+/**
+ * Equivalence tests for the {@code BeamSearch.bestSequences} refactor that replaced
+ * per-candidate {@link Sequence} copies with internal chain nodes ({@code SearchNode}).
+ * <p>
+ * Every test runs the current {@link BeamSearch} side by side with
+ * {@link #referenceBestSequences}, a faithful port of the pre-refactor implementation
+ * (as of {@code HEAD~1}), and demands identical output: same number of sequences,
+ * identical outcome lists (order-sensitive), and bit-identical scores and
+ * per-position probabilities.
+ */
+public class BeamSearchEquivalenceTest {
+
+  /** Mirror of the private {@code BeamSearch.ZERO_LOG} default threshold. */
+  private static final double ZERO_LOG = -100000;
+
+  private static final int NUM_OUTCOMES = 4;
+  private static final long MODEL_SEED = 0x5eedL;
+
+  private static final int[] BEAM_SIZES = {1, 2, 3, 5, 10}; // 10 > NUM_OUTCOMES on purpose
+  private static final int[] INPUT_LENGTHS = {0, 1, 2, 7, 33, 128};
+  private static final int[] CACHE_SIZES = {0, 64};
+
+  private static final SequenceValidator<String> ACCEPT_ALL =
+      (i, input, outcomes, outcome) -> true;
+
+  // ---------------------------------------------------------------------------
+  // Seeded pseudo-random model
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A {@link MaxentModel} whose probabilities are a deterministic pseudo-random
+   * function of the joined context strings and the outcome index. Repeated evals of
+   * the same context therefore return identical values. Values lie in (0, 1] and are
+   * intentionally not normalized. The {@code eval(context, probs)} buffer contract is
+   * honored: values are written into the passed array and that same array is returned.
+   */
+  static final class SeededModel implements MaxentModel {
+
+    private final String[] outcomes;
+    private final long seed;
+
+    SeededModel(int numOutcomes, long seed) {
+      this.outcomes = new String[numOutcomes];
+      for (int i = 0; i < numOutcomes; i++) {
+        this.outcomes[i] = "o" + i;
+      }
+      this.seed = seed;
+    }
+
+    private double prob(String[] context, int outcomeIndex) {
+      long h = seed;
+      for (String c : context) {
+        h = mix(h, c.hashCode());
+      }
+      h = mix(h, outcomeIndex);
+      // splitmix64 finalizer for avalanche
+      h ^= h >>> 30;
+      h *= 0xBF58476D1CE4E5B9L;
+      h ^= h >>> 27;
+      h *= 0x94D049BB133111EBL;
+      h ^= h >>> 31;
+      double u = (h >>> 11) * (1.0 / (1L << 53)); // [0, 1)
+      return 0.01 + 0.98 * u; // (0.01, 0.99]
+    }
+
+    private static long mix(long h, long v) {
+      return (h ^ (v + 0x9E3779B97F4A7C15L)) * 0x100000001B3L;
+    }
+
+    @Override
+    public double[] eval(String[] context) {
+      return eval(context, new double[outcomes.length]);
+    }
+
+    @Override
+    public double[] eval(String[] context, double[] probs) {
+      for (int i = 0; i < outcomes.length; i++) {
+        probs[i] = prob(context, i);
+      }
+      return probs; // buffer contract: write into the passed array AND return it
+    }
+
+    @Override
+    public double[] eval(String[] context, float[] values) {
+      return eval(context);
+    }
+
+    @Override
+    public String getOutcome(int i) {
+      return outcomes[i];
+    }
+
+    @Override
+    public int getNumOutcomes() {
+      return outcomes.length;
+    }
+
+    @Override
+    public String getAllOutcomes(double[] outcomes) {
+      return null;
+    }
+
+    @Override
+    public String getBestOutcome(double[] outcomes) {
+      return null;
+    }
+
+    @Override
+    public int getIndex(String outcome) {
+      for (int i = 0; i < outcomes.length; i++) {
+        if (outcomes[i].equals(outcome)) {
+          return i;
+        }
+      }
+      return -1;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Context generator
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds contexts from the index, the token, the previous outcome and the first
+   * additional-context element. Identical context content is interned to the same
+   * {@code String[]} instance so the identity-keyed contexts {@link Cache} in
+   * {@link BeamSearch} actually produces hits. Thread-safe.
+   */
+  static final class SeededContextGenerator implements BeamSearchContextGenerator<String> {
+
+    private final ConcurrentHashMap<String, String[]> intern = new ConcurrentHashMap<>();
+    private final AtomicInteger callCount = new AtomicInteger();
+
+    @Override
+    public String[] getContext(int index, String[] sequence,
+                               String[] priorDecisions, Object[] additionalContext) {
+      callCount.incrementAndGet();
+      String prev = index > 0 ? priorDecisions[index - 1] : "<s>";
+      String ac = additionalContext != null && additionalContext.length > 0
+          ? String.valueOf(additionalContext[0]) : "-";
+      String[] ctx = {"ix=" + index, "tok=" + sequence[index], "prev=" + prev, "ac=" + ac};
+      String key = String.join("", ctx);
+      String[] existing = intern.putIfAbsent(key, ctx);
+      return existing != null ? existing : ctx;
+    }
+
+    int callCount() {
+      return callCount.get();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reference implementation: faithful port of the pre-refactor bestSequences
+  // (git show HEAD~1:.../opennlp/tools/ml/BeamSearch.java)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Port of the OLD {@code BeamSearch.bestSequences} control flow: PriorityQueue over
+   * {@link Sequence}, per-candidate {@code new Sequence(top, out, scores[p])} copies,
+   * tempScores sort/min, the {@code next.isEmpty()} advance-all-valid fallback, the
+   * queue swap, and the winner removal order. The cache path (a
+   * {@code Cache<String[], double[]>} exactly like the old per-thread one) is used
+   * when {@code cacheSize > 0}; otherwise the uncached eval path is taken.
+   */
+  static <T> Sequence[] referenceBestSequences(
+      final int numSequences, final T[] sequence, final Object[] additionalContext,
+      final double minSequenceScore, final BeamSearchContextGenerator<T> cg,
+      final SequenceValidator<T> validator, final MaxentModel model,
+      final int beamSize, final int cacheSize) {
+
+    // Local equivalents of the old per-thread CacheState.
+    final double[] probs = new double[model.getNumOutcomes()];
+    final double[] tempScores = new double[model.getNumOutcomes()];
+    final Cache<String[], double[]> cache = cacheSize > 0 ? new Cache<>(cacheSize) : null;
+
+    Queue<Sequence> prev = new PriorityQueue<>(beamSize);
+    Queue<Sequence> next = new PriorityQueue<>(beamSize);
+    Queue<Sequence> tmp;
+    prev.add(new Sequence());
+
+    Object[] context = additionalContext;
+    if (context == null) {
+      context = new Object[0];
+    }
+
+    for (int i = 0; i < sequence.length; i++) {
+      final int sz = StrictMath.min(beamSize, prev.size());
+
+      for (int sc = 0; prev.size() > 0 && sc < sz; sc++) {
+        final Sequence top = prev.remove();
+        final List<String> tmpOutcomes = top.getOutcomes();
+        final String[] outcomes = tmpOutcomes.toArray(new String[0]);
+        final String[] contexts = cg.getContext(i, sequence, outcomes, context);
+        final double[] scores;
+        if (cache != null) {
+          scores = cache.computeIfAbsent(contexts, c -> {
+            double[] res = model.eval(c, probs);
+            double[] copy = new double[res.length];
+            System.arraycopy(res, 0, copy, 0, res.length);
+            return copy;
+          });
+        } else {
+          scores = model.eval(contexts, probs);
+        }
+
+        System.arraycopy(scores, 0, tempScores, 0, scores.length);
+        Arrays.sort(tempScores);
+
+        final double min = tempScores[StrictMath.max(0, scores.length - beamSize)];
+
+        for (int p = 0; p < scores.length; p++) {
+          if (scores[p] >= min) {
+            final String out = model.getOutcome(p);
+            if (validator.validSequence(i, sequence, outcomes, out)) {
+              final Sequence ns = new Sequence(top, out, scores[p]);
+              if (ns.getScore() > minSequenceScore) {
+                next.add(ns);
+              }
+            }
+          }
+        }
+
+        if (next.isEmpty()) { // if no advanced sequences, advance all valid
+          for (int p = 0; p < scores.length; p++) {
+            final String out = model.getOutcome(p);
+            if (validator.validSequence(i, sequence, outcomes, out)) {
+              final Sequence ns = new Sequence(top, out, scores[p]);
+              if (ns.getScore() > minSequenceScore) {
+                next.add(ns);
+              }
+            }
+          }
+        }
+      }
+
+      // make prev = next; and re-init next (reuse existing prev set once cleared)
+      prev.clear();
+      tmp = prev;
+      prev = next;
+      next = tmp;
+    }
+
+    final int numSeq = StrictMath.min(numSequences, prev.size());
+    final Sequence[] topSequences = new Sequence[numSeq];
+
+    for (int seqIndex = 0; seqIndex < numSeq; seqIndex++) {
+      topSequences[seqIndex] = prev.remove();
+    }
+
+    return topSequences;
+  }
+
+  /** Reference twin of the two-arg overload (default {@code ZERO_LOG} threshold). */
+  static <T> Sequence[] referenceBestSequences(
+      int numSequences, T[] sequence, Object[] additionalContext,
+      BeamSearchContextGenerator<T> cg, SequenceValidator<T> validator,
+      MaxentModel model, int beamSize, int cacheSize) {
+    return referenceBestSequences(numSequences, sequence, additionalContext, ZERO_LOG,
+        cg, validator, model, beamSize, cacheSize);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static String[] randomInput(int length, long seed) {
+    Random rnd = new Random(seed);
+    String[] input = new String[length];
+    for (int i = 0; i < length; i++) {
+      input[i] = "t" + rnd.nextInt(17);
+    }
+    return input;
+  }
+
+  private static void assertBitIdentical(double expected, double actual, String what) {
+    Assertions.assertEquals(Double.doubleToRawLongBits(expected),
+        Double.doubleToRawLongBits(actual),
+        what + " (expected=" + expected + ", actual=" + actual + ")");
+  }
+
+  private static void assertSequencesEqual(Sequence[] expected, Sequence[] actual,
+                                           String caseDesc) {
+    Assertions.assertNotNull(actual, caseDesc + ": result array must not be null");
+    Assertions.assertEquals(expected.length, actual.length,
+        caseDesc + ": number of returned sequences");
+    for (int s = 0; s < expected.length; s++) {
+      String seqDesc = caseDesc + ", sequence[" + s + "]";
+      Assertions.assertEquals(expected[s].getOutcomes(), actual[s].getOutcomes(),
+          seqDesc + ": outcomes");
+      assertBitIdentical(expected[s].getScore(), actual[s].getScore(),
+          seqDesc + ": score");
+      Assertions.assertEquals(expected[s].getSize(), actual[s].getSize(),
+          seqDesc + ": size");
+      double[] expectedProbs = expected[s].getProbs();
+      double[] actualProbs = actual[s].getProbs();
+      Assertions.assertEquals(expectedProbs.length, actualProbs.length,
+          seqDesc + ": probs length");
+      for (int p = 0; p < expectedProbs.length; p++) {
+        assertBitIdentical(expectedProbs[p], actualProbs[p],
+            seqDesc + ": prob[" + p + "]");
+        assertBitIdentical(expected[s].getProb(p), actual[s].getProb(p),
+            seqDesc + ": getProb(" + p + ")");
+      }
+    }
+  }
+
+  private static String caseDesc(String test, int beam, int length, int cache) {
+    return test + "[beam=" + beam + ", len=" + length + ", cache=" + cache + "]";
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. Equivalence matrix: beam sizes x input lengths x cache sizes,
+  //    default (ZERO_LOG) threshold via the two-arg overload, accept-all validator
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void equivalenceAcrossBeamSizesLengthsAndCaches() {
+    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+    for (int beam : BEAM_SIZES) {
+      for (int length : INPUT_LENGTHS) {
+        String[] input = randomInput(length, 1000L + length);
+        for (int cache : CACHE_SIZES) {
+          String desc = caseDesc("matrix", beam, length, cache);
+          SeededContextGenerator cg = new SeededContextGenerator();
+
+          Sequence[] expected = referenceBestSequences(1, input, null, cg, ACCEPT_ALL,
+              model, beam, cache);
+          Sequence[] actual = new BeamSearch(beam, model, cache)
+              .bestSequences(1, input, null, cg, ACCEPT_ALL);
+
+          assertSequencesEqual(expected, actual, desc);
+          if (length == 0) {
+            Assertions.assertEquals(0, cg.callCount(),
+                desc + ": context generator must not be called for empty input");
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. Equivalence with a tight minSequenceScore that actually filters candidates
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void equivalenceWithTightMinSequenceScore() {
+    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+    for (int beam : BEAM_SIZES) {
+      for (int length : INPUT_LENGTHS) {
+        String[] input = randomInput(length, 2000L + length);
+        for (int cache : CACHE_SIZES) {
+          String desc = caseDesc("threshold", beam, length, cache);
+
+          // Derive a threshold that bites: run uncapped, then cut between the best
+          // and worst candidate scores (or just above the best when only one exists).
+          Sequence[] uncapped = referenceBestSequences(beam, input, null,
+              new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
+          final double threshold;
+          if (uncapped.length == 0) {
+            threshold = 0;
+          } else {
+            double best = uncapped[0].getScore();
+            double worst = uncapped[uncapped.length - 1].getScore();
+            threshold = (uncapped.length > 1 && worst < best)
+                ? (best + worst) / 2.0 : best + 0.5;
+          }
+
+          Sequence[] expected = referenceBestSequences(1, input, null, threshold,
+              new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
+          Sequence[] actual = new BeamSearch(beam, model, cache)
+              .bestSequences(1, input, null, threshold, new SeededContextGenerator(),
+                  ACCEPT_ALL);
+
+          assertSequencesEqual(expected, actual, desc + ", threshold=" + threshold);
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. Equivalence under restrictive validators, including the next.isEmpty()
+  //    advance-all-valid fallback and the reject-everything empty-result path
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void equivalenceWithRestrictiveValidators() {
+    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+
+    SequenceValidator<String> rejectOneOutcome =
+        (i, input, outcomes, outcome) -> !"o2".equals(outcome);
+    // Rejects every outcome at position 2: at that position the threshold loop adds
+    // nothing, so the next.isEmpty() fallback runs (and also rejects everything,
+    // killing the search for inputs longer than 2).
+    SequenceValidator<String> rejectAllAtPosition2 =
+        (i, input, outcomes, outcome) -> i != 2;
+    // Rejects everything except "o3" at position 2: the fallback actually populates
+    // next with the sub-threshold "o3" candidate whenever "o3" fell below the min.
+    SequenceValidator<String> onlyO3AtPosition2 =
+        (i, input, outcomes, outcome) -> i != 2 || "o3".equals(outcome);
+    SequenceValidator<String> rejectEverything =
+        (i, input, outcomes, outcome) -> false;
+
+    record NamedValidator(String name, SequenceValidator<String> validator) {}
+    List<NamedValidator> validators = List.of(
+        new NamedValidator("rejectOneOutcome", rejectOneOutcome),
+        new NamedValidator("rejectAllAtPosition2", rejectAllAtPosition2),
+        new NamedValidator("onlyO3AtPosition2", onlyO3AtPosition2),
+        new NamedValidator("rejectEverything", rejectEverything));
+
+    for (NamedValidator nv : validators) {
+      for (int beam : BEAM_SIZES) {
+        for (int length : INPUT_LENGTHS) {
+          String[] input = randomInput(length, 3000L + length);
+          for (int cache : CACHE_SIZES) {
+            String desc = caseDesc("validator-" + nv.name(), beam, length, cache);
+
+            Sequence[] expected = referenceBestSequences(1, input, null,
+                new SeededContextGenerator(), nv.validator(), model, beam, cache);
+            Sequence[] actual = new BeamSearch(beam, model, cache)
+                .bestSequences(1, input, null, new SeededContextGenerator(),
+                    nv.validator());
+
+            assertSequencesEqual(expected, actual, desc);
+            if ("rejectEverything".equals(nv.name()) && length > 0) {
+              Assertions.assertEquals(0, actual.length,
+                  desc + ": reject-everything must yield an empty (non-null) array");
+              Assertions.assertEquals(0, expected.length,
+                  desc + ": reference reject-everything must also be empty");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 4. numSequences > 1: winner order and scores match the reference exactly
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void multiWinnerOrderingMatchesReference() {
+    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+    int beam = 5;
+    int numSequences = 3;
+    Object[] additionalContext = {"ac-ctx"};
+    for (int length : INPUT_LENGTHS) {
+      String[] input = randomInput(length, 4000L + length);
+      for (int cache : CACHE_SIZES) {
+        String desc = caseDesc("multiWinner[k=3]", beam, length, cache);
+
+        Sequence[] expected = referenceBestSequences(numSequences, input,
+            additionalContext, new SeededContextGenerator(), ACCEPT_ALL,
+            model, beam, cache);
+        Sequence[] actual = new BeamSearch(beam, model, cache)
+            .bestSequences(numSequences, input, additionalContext,
+                new SeededContextGenerator(), ACCEPT_ALL);
+
+        assertSequencesEqual(expected, actual, desc);
+        if (length > 0) {
+          Assertions.assertEquals(numSequences, actual.length,
+              desc + ": expected a full k-best list");
+          // Winners must come out in non-increasing score order.
+          for (int s = 1; s < actual.length; s++) {
+            Assertions.assertTrue(actual[s - 1].getScore() >= actual[s].getScore(),
+                desc + ": winner order not non-increasing at index " + s);
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 5. Concurrency determinism: one shared BeamSearch, 8 worker threads
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void concurrentResultsMatchSerialReference() throws Exception {
+    final int numInputs = 64;
+    final int rounds = 4; // 64 x 4 = 256 decode evaluations across the pool
+    final int numThreads = 8;
+    final int beam = 3;
+    final int cache = 64;
+
+    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+    BeamSearch shared = new BeamSearch(beam, model, cache);
+
+    String[][] inputs = new String[numInputs][];
+    for (int n = 0; n < numInputs; n++) {
+      inputs[n] = randomInput(n, 5000L + n); // lengths 0..63
+    }
+    SeededContextGenerator cg = new SeededContextGenerator();
+
+    // Serial reference results, one per input.
+    Sequence[][] reference = new Sequence[numInputs][];
+    for (int n = 0; n < numInputs; n++) {
+      reference[n] = referenceBestSequences(1, inputs[n], null, cg, ACCEPT_ALL,
+          model, beam, cache);
+    }
+
+    // Run 1: 8 workers, each with a disjoint subset of inputs, `rounds` passes each.
+    Sequence[][][] runResults = new Sequence[rounds][numInputs][];
+    ExecutorService pool = Executors.newFixedThreadPool(numThreads);
+    try {
+      List<Future<?>> futures = new ArrayList<>();
+      for (int w = 0; w < numThreads; w++) {
+        final int worker = w;
+        futures.add(pool.submit(() -> {
+          for (int round = 0; round < rounds; round++) {
+            for (int n = worker; n < numInputs; n += numThreads) {
+              runResults[round][n] = shared.bestSequences(1, inputs[n], null, cg,
+                  ACCEPT_ALL);
+            }
+          }
+        }));
+      }
+      for (Future<?> f : futures) {
+        f.get();
+      }
+    } finally {
+      pool.shutdown();
+    }
+
+    for (int round = 0; round < rounds; round++) {
+      for (int n = 0; n < numInputs; n++) {
+        assertSequencesEqual(reference[n], runResults[round][n],
+            "concurrent[round=" + round + ", input=" + n + ", len=" + inputs[n].length
+                + "]");
+      }
+    }
+
+    // Run 2: the SAME input set twice concurrently; the two passes must agree with
+    // each other (and with the serial reference).
+    Sequence[][] passA = new Sequence[numInputs][];
+    Sequence[][] passB = new Sequence[numInputs][];
+    ExecutorService pool2 = Executors.newFixedThreadPool(numThreads);
+    try {
+      Future<?> fa = pool2.submit(() -> {
+        for (int n = 0; n < numInputs; n++) {
+          passA[n] = shared.bestSequences(1, inputs[n], null, cg, ACCEPT_ALL);
+        }
+      });
+      Future<?> fb = pool2.submit(() -> {
+        for (int n = numInputs - 1; n >= 0; n--) { // reverse order, still racing passA
+          passB[n] = shared.bestSequences(1, inputs[n], null, cg, ACCEPT_ALL);
+        }
+      });
+      fa.get();
+      fb.get();
+    } finally {
+      pool2.shutdown();
+    }
+
+    for (int n = 0; n < numInputs; n++) {
+      assertSequencesEqual(passA[n], passB[n],
+          "concurrent-agreement[input=" + n + "]");
+      assertSequencesEqual(reference[n], passA[n],
+          "concurrent-vs-reference[input=" + n + "]");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 6. Winner materialization: outcomes, per-position probs and score of the
+  //    winning Sequence are consistent with the model's eval outputs
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void winnerMaterializationMatchesModelOutputs() {
+    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+    String[] input = randomInput(7, 6000L);
+    int beam = 3;
+
+    for (int cache : CACHE_SIZES) {
+      String desc = "materialization[cache=" + cache + "]";
+      BeamSearch bs = new BeamSearch(beam, model, cache);
+      Sequence winner = bs.bestSequence(input, null, new SeededContextGenerator(),
+          ACCEPT_ALL);
+      Assertions.assertNotNull(winner, desc);
+      Assertions.assertEquals(input.length, winner.getSize(), desc + ": size");
+
+      // The winner must equal the reference winner.
+      Sequence refWinner = referenceBestSequences(1, input, null,
+          new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache)[0];
+      Assertions.assertEquals(refWinner.getOutcomes(), winner.getOutcomes(),
+          desc + ": outcomes vs reference");
+
+      // Walk the winning path and recompute the expected probs/score independently.
+      List<String> outcomes = winner.getOutcomes();
+      double[] probs = winner.getProbs();
+      double expectedScore = 0d;
+      SeededContextGenerator cg = new SeededContextGenerator();
+      for (int i = 0; i < outcomes.size(); i++) {
+        String[] prefix = outcomes.subList(0, i).toArray(new String[0]);
+        String[] contexts = cg.getContext(i, input, prefix, new Object[0]);
+        double[] eval = model.eval(contexts);
+        int outcomeIndex = model.getIndex(outcomes.get(i));
+        Assertions.assertTrue(outcomeIndex >= 0, desc + ": outcome known to model");
+        double expectedProb = eval[outcomeIndex];
+
+        assertBitIdentical(expectedProb, probs[i], desc + ": getProbs()[" + i + "]");
+        assertBitIdentical(expectedProb, winner.getProb(i),
+            desc + ": getProb(" + i + ")");
+        expectedScore += StrictMath.log(expectedProb);
+      }
+      assertBitIdentical(expectedScore, winner.getScore(), desc + ": score");
+    }
+  }
+}

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/BeamSearchEquivalenceTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/BeamSearchEquivalenceTest.java
@@ -28,9 +28,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import opennlp.tools.ml.model.MaxentModel;
 import opennlp.tools.util.BeamSearchContextGenerator;
@@ -39,122 +44,52 @@ import opennlp.tools.util.Sequence;
 import opennlp.tools.util.SequenceValidator;
 
 /**
- * Equivalence tests for the {@code BeamSearch.bestSequences} refactor that replaced
- * per-candidate {@link Sequence} copies with internal chain nodes ({@code SearchNode}).
+ * Equivalence tests for the {@code BeamSearch.bestSequences} chain-node implementation
+ * introduced with OPENNLP-1903.
  * <p>
  * Every test runs the current {@link BeamSearch} side by side with
- * {@link #referenceBestSequences}, a faithful port of the pre-refactor implementation
- * (as of {@code HEAD~1}), and demands identical output: same number of sequences,
- * identical outcome lists (order-sensitive), and bit-identical scores and
- * per-position probabilities.
+ * {@link #referenceBestSequences}, a faithful port of the per-candidate
+ * {@link Sequence}-copying implementation that OPENNLP-1903 replaced, and demands
+ * identical output: same number of sequences, identical outcome lists
+ * (order-sensitive), and bit-identical scores and per-position probabilities.
  */
 public class BeamSearchEquivalenceTest {
 
   /** Mirror of the private {@code BeamSearch.ZERO_LOG} default threshold. */
   private static final double ZERO_LOG = -100000;
 
-  private static final int NUM_OUTCOMES = 4;
+  private static final String[] OUTCOMES = {"o0", "o1", "o2", "o3"};
   private static final long MODEL_SEED = 0x5eedL;
 
-  private static final int[] BEAM_SIZES = {1, 2, 3, 5, 10}; // 10 > NUM_OUTCOMES on purpose
+  private static final int[] BEAM_SIZES = {1, 2, 3, 5, 10}; // 10 > OUTCOMES.length on purpose
   private static final int[] INPUT_LENGTHS = {0, 1, 2, 7, 33, 128};
   private static final int[] CACHE_SIZES = {0, 64};
 
   private static final SequenceValidator<String> ACCEPT_ALL =
       (i, input, outcomes, outcome) -> true;
 
-  // ---------------------------------------------------------------------------
-  // Seeded pseudo-random model
-  // ---------------------------------------------------------------------------
-
-  /**
-   * A {@link MaxentModel} whose probabilities are a deterministic pseudo-random
-   * function of the joined context strings and the outcome index. Repeated evals of
-   * the same context therefore return identical values. Values lie in (0, 1] and are
-   * intentionally not normalized. The {@code eval(context, probs)} buffer contract is
-   * honored: values are written into the passed array and that same array is returned.
-   */
-  static final class SeededModel implements MaxentModel {
-
-    private final String[] outcomes;
-    private final long seed;
-
-    SeededModel(int numOutcomes, long seed) {
-      this.outcomes = new String[numOutcomes];
-      for (int i = 0; i < numOutcomes; i++) {
-        this.outcomes[i] = "o" + i;
-      }
-      this.seed = seed;
-    }
-
-    private double prob(String[] context, int outcomeIndex) {
-      long h = seed;
-      for (String c : context) {
-        h = mix(h, c.hashCode());
-      }
-      h = mix(h, outcomeIndex);
-      // splitmix64 finalizer for avalanche
-      h ^= h >>> 30;
-      h *= 0xBF58476D1CE4E5B9L;
-      h ^= h >>> 27;
-      h *= 0x94D049BB133111EBL;
-      h ^= h >>> 31;
-      double u = (h >>> 11) * (1.0 / (1L << 53)); // [0, 1)
-      return 0.01 + 0.98 * u; // (0.01, 0.99]
-    }
-
-    private static long mix(long h, long v) {
-      return (h ^ (v + 0x9E3779B97F4A7C15L)) * 0x100000001B3L;
-    }
-
+  /** A {@link SequenceValidator} paired with a stable name for test display. */
+  record NamedValidator(String name, SequenceValidator<String> validator) {
     @Override
-    public double[] eval(String[] context) {
-      return eval(context, new double[outcomes.length]);
-    }
-
-    @Override
-    public double[] eval(String[] context, double[] probs) {
-      for (int i = 0; i < outcomes.length; i++) {
-        probs[i] = prob(context, i);
-      }
-      return probs; // buffer contract: write into the passed array AND return it
-    }
-
-    @Override
-    public double[] eval(String[] context, float[] values) {
-      return eval(context);
-    }
-
-    @Override
-    public String getOutcome(int i) {
-      return outcomes[i];
-    }
-
-    @Override
-    public int getNumOutcomes() {
-      return outcomes.length;
-    }
-
-    @Override
-    public String getAllOutcomes(double[] outcomes) {
-      return null;
-    }
-
-    @Override
-    public String getBestOutcome(double[] outcomes) {
-      return null;
-    }
-
-    @Override
-    public int getIndex(String outcome) {
-      for (int i = 0; i < outcomes.length; i++) {
-        if (outcomes[i].equals(outcome)) {
-          return i;
-        }
-      }
-      return -1;
+    public String toString() {
+      return name;
     }
   }
+
+  private static final List<NamedValidator> VALIDATORS = List.of(
+      new NamedValidator("rejectOneOutcome",
+          (i, input, outcomes, outcome) -> !"o2".equals(outcome)),
+      // Rejects every outcome at position 2: at that position the threshold loop adds
+      // nothing, so the next.isEmpty() fallback runs (and also rejects everything,
+      // killing the search for inputs longer than 2).
+      new NamedValidator("rejectAllAtPosition2",
+          (i, input, outcomes, outcome) -> i != 2),
+      // Rejects everything except "o3" at position 2: the fallback actually populates
+      // next with the sub-threshold "o3" candidate whenever "o3" fell below the min.
+      new NamedValidator("onlyO3AtPosition2",
+          (i, input, outcomes, outcome) -> i != 2 || "o3".equals(outcome)),
+      new NamedValidator("rejectEverything",
+          (i, input, outcomes, outcome) -> false));
 
   // ---------------------------------------------------------------------------
   // Context generator
@@ -184,23 +119,27 @@ public class BeamSearchEquivalenceTest {
       return existing != null ? existing : ctx;
     }
 
+    /**
+     * @return The number of {@link #getContext} invocations so far.
+     */
     int callCount() {
       return callCount.get();
     }
   }
 
   // ---------------------------------------------------------------------------
-  // Reference implementation: faithful port of the pre-refactor bestSequences
-  // (git show HEAD~1:.../opennlp/tools/ml/BeamSearch.java)
+  // Reference implementation: faithful port of the bestSequences implementation
+  // prior to OPENNLP-1903
   // ---------------------------------------------------------------------------
 
   /**
-   * Port of the OLD {@code BeamSearch.bestSequences} control flow: PriorityQueue over
-   * {@link Sequence}, per-candidate {@code new Sequence(top, out, scores[p])} copies,
-   * tempScores sort/min, the {@code next.isEmpty()} advance-all-valid fallback, the
-   * queue swap, and the winner removal order. The cache path (a
-   * {@code Cache<String[], double[]>} exactly like the old per-thread one) is used
-   * when {@code cacheSize > 0}; otherwise the uncached eval path is taken.
+   * Port of the {@code BeamSearch.bestSequences} control flow prior to OPENNLP-1903:
+   * PriorityQueue over {@link Sequence}, per-candidate
+   * {@code new Sequence(top, out, scores[p])} copies, tempScores sort/min, the
+   * {@code next.isEmpty()} advance-all-valid fallback, the queue swap, and the winner
+   * removal order. The cache path (a {@code Cache<String[], double[]>} exactly like the
+   * per-thread one in {@link BeamSearch}) is used when {@code cacheSize > 0}; otherwise
+   * the uncached eval path is taken.
    */
   static <T> Sequence[] referenceBestSequences(
       final int numSequences, final T[] sequence, final Object[] additionalContext,
@@ -208,7 +147,7 @@ public class BeamSearchEquivalenceTest {
       final SequenceValidator<T> validator, final MaxentModel model,
       final int beamSize, final int cacheSize) {
 
-    // Local equivalents of the old per-thread CacheState.
+    // Local equivalents of the per-thread CacheState in BeamSearch.
     final double[] probs = new double[model.getNumOutcomes()];
     final double[] tempScores = new double[model.getNumOutcomes()];
     final Cache<String[], double[]> cache = cacheSize > 0 ? new Cache<>(cacheSize) : null;
@@ -303,6 +242,16 @@ public class BeamSearchEquivalenceTest {
   // Helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * @return A new model over {@link #OUTCOMES} seeded with {@link #MODEL_SEED}.
+   */
+  private static MaxentModel model() {
+    return new SeededMaxentModel(OUTCOMES, MODEL_SEED);
+  }
+
+  /**
+   * @return A seeded pseudo-random token sequence of {@code length} tokens.
+   */
   private static String[] randomInput(int length, long seed) {
     Random rnd = new Random(seed);
     String[] input = new String[length];
@@ -349,32 +298,85 @@ public class BeamSearchEquivalenceTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Parameter sources
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @return The cartesian product of {@link #BEAM_SIZES}, {@link #INPUT_LENGTHS}
+   *         and {@link #CACHE_SIZES}.
+   */
+  static Stream<Arguments> beamLengthCacheMatrix() {
+    Stream.Builder<Arguments> cases = Stream.builder();
+    for (int beam : BEAM_SIZES) {
+      for (int length : INPUT_LENGTHS) {
+        for (int cache : CACHE_SIZES) {
+          cases.add(Arguments.of(beam, length, cache));
+        }
+      }
+    }
+    return cases.build();
+  }
+
+  /**
+   * @return The cartesian product of {@link #VALIDATORS}, {@link #BEAM_SIZES},
+   *         {@link #INPUT_LENGTHS} and {@link #CACHE_SIZES}.
+   */
+  static Stream<Arguments> validatorBeamLengthCacheMatrix() {
+    Stream.Builder<Arguments> cases = Stream.builder();
+    for (NamedValidator nv : VALIDATORS) {
+      for (int beam : BEAM_SIZES) {
+        for (int length : INPUT_LENGTHS) {
+          for (int cache : CACHE_SIZES) {
+            cases.add(Arguments.of(nv, beam, length, cache));
+          }
+        }
+      }
+    }
+    return cases.build();
+  }
+
+  /**
+   * @return The cartesian product of {@link #INPUT_LENGTHS} and {@link #CACHE_SIZES}.
+   */
+  static Stream<Arguments> lengthCacheMatrix() {
+    Stream.Builder<Arguments> cases = Stream.builder();
+    for (int length : INPUT_LENGTHS) {
+      for (int cache : CACHE_SIZES) {
+        cases.add(Arguments.of(length, cache));
+      }
+    }
+    return cases.build();
+  }
+
+  /**
+   * @return All values of {@link #CACHE_SIZES}.
+   */
+  static IntStream cacheSizes() {
+    return IntStream.of(CACHE_SIZES);
+  }
+
+  // ---------------------------------------------------------------------------
   // 1. Equivalence matrix: beam sizes x input lengths x cache sizes,
   //    default (ZERO_LOG) threshold via the two-arg overload, accept-all validator
   // ---------------------------------------------------------------------------
 
-  @Test
-  void equivalenceAcrossBeamSizesLengthsAndCaches() {
-    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
-    for (int beam : BEAM_SIZES) {
-      for (int length : INPUT_LENGTHS) {
-        String[] input = randomInput(length, 1000L + length);
-        for (int cache : CACHE_SIZES) {
-          String desc = caseDesc("matrix", beam, length, cache);
-          SeededContextGenerator cg = new SeededContextGenerator();
+  @ParameterizedTest(name = "beam={0}, len={1}, cache={2}")
+  @MethodSource("beamLengthCacheMatrix")
+  void equivalenceAcrossBeamSizesLengthsAndCaches(int beam, int length, int cache) {
+    MaxentModel model = model();
+    String[] input = randomInput(length, 1000L + length);
+    String desc = caseDesc("matrix", beam, length, cache);
+    SeededContextGenerator cg = new SeededContextGenerator();
 
-          Sequence[] expected = referenceBestSequences(1, input, null, cg, ACCEPT_ALL,
-              model, beam, cache);
-          Sequence[] actual = new BeamSearch(beam, model, cache)
-              .bestSequences(1, input, null, cg, ACCEPT_ALL);
+    Sequence[] expected = referenceBestSequences(1, input, null, cg, ACCEPT_ALL,
+        model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(1, input, null, cg, ACCEPT_ALL);
 
-          assertSequencesEqual(expected, actual, desc);
-          if (length == 0) {
-            Assertions.assertEquals(0, cg.callCount(),
-                desc + ": context generator must not be called for empty input");
-          }
-        }
-      }
+    assertSequencesEqual(expected, actual, desc);
+    if (length == 0) {
+      Assertions.assertEquals(0, cg.callCount(),
+          desc + ": context generator must not be called for empty input");
     }
   }
 
@@ -382,39 +384,34 @@ public class BeamSearchEquivalenceTest {
   // 2. Equivalence with a tight minSequenceScore that actually filters candidates
   // ---------------------------------------------------------------------------
 
-  @Test
-  void equivalenceWithTightMinSequenceScore() {
-    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
-    for (int beam : BEAM_SIZES) {
-      for (int length : INPUT_LENGTHS) {
-        String[] input = randomInput(length, 2000L + length);
-        for (int cache : CACHE_SIZES) {
-          String desc = caseDesc("threshold", beam, length, cache);
+  @ParameterizedTest(name = "beam={0}, len={1}, cache={2}")
+  @MethodSource("beamLengthCacheMatrix")
+  void equivalenceWithTightMinSequenceScore(int beam, int length, int cache) {
+    MaxentModel model = model();
+    String[] input = randomInput(length, 2000L + length);
+    String desc = caseDesc("threshold", beam, length, cache);
 
-          // Derive a threshold that bites: run uncapped, then cut between the best
-          // and worst candidate scores (or just above the best when only one exists).
-          Sequence[] uncapped = referenceBestSequences(beam, input, null,
-              new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
-          final double threshold;
-          if (uncapped.length == 0) {
-            threshold = 0;
-          } else {
-            double best = uncapped[0].getScore();
-            double worst = uncapped[uncapped.length - 1].getScore();
-            threshold = (uncapped.length > 1 && worst < best)
-                ? (best + worst) / 2.0 : best + 0.5;
-          }
-
-          Sequence[] expected = referenceBestSequences(1, input, null, threshold,
-              new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
-          Sequence[] actual = new BeamSearch(beam, model, cache)
-              .bestSequences(1, input, null, threshold, new SeededContextGenerator(),
-                  ACCEPT_ALL);
-
-          assertSequencesEqual(expected, actual, desc + ", threshold=" + threshold);
-        }
-      }
+    // Derive a threshold that bites: run uncapped, then cut between the best
+    // and worst candidate scores (or just above the best when only one exists).
+    Sequence[] uncapped = referenceBestSequences(beam, input, null,
+        new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
+    final double threshold;
+    if (uncapped.length == 0) {
+      threshold = 0;
+    } else {
+      double best = uncapped[0].getScore();
+      double worst = uncapped[uncapped.length - 1].getScore();
+      threshold = (uncapped.length > 1 && worst < best)
+          ? (best + worst) / 2.0 : best + 0.5;
     }
+
+    Sequence[] expected = referenceBestSequences(1, input, null, threshold,
+        new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(1, input, null, threshold, new SeededContextGenerator(),
+            ACCEPT_ALL);
+
+    assertSequencesEqual(expected, actual, desc + ", threshold=" + threshold);
   }
 
   // ---------------------------------------------------------------------------
@@ -422,54 +419,26 @@ public class BeamSearchEquivalenceTest {
   //    advance-all-valid fallback and the reject-everything empty-result path
   // ---------------------------------------------------------------------------
 
-  @Test
-  void equivalenceWithRestrictiveValidators() {
-    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+  @ParameterizedTest(name = "{0}, beam={1}, len={2}, cache={3}")
+  @MethodSource("validatorBeamLengthCacheMatrix")
+  void equivalenceWithRestrictiveValidators(NamedValidator nv, int beam, int length,
+                                            int cache) {
+    MaxentModel model = model();
+    String[] input = randomInput(length, 3000L + length);
+    String desc = caseDesc("validator-" + nv.name(), beam, length, cache);
 
-    SequenceValidator<String> rejectOneOutcome =
-        (i, input, outcomes, outcome) -> !"o2".equals(outcome);
-    // Rejects every outcome at position 2: at that position the threshold loop adds
-    // nothing, so the next.isEmpty() fallback runs (and also rejects everything,
-    // killing the search for inputs longer than 2).
-    SequenceValidator<String> rejectAllAtPosition2 =
-        (i, input, outcomes, outcome) -> i != 2;
-    // Rejects everything except "o3" at position 2: the fallback actually populates
-    // next with the sub-threshold "o3" candidate whenever "o3" fell below the min.
-    SequenceValidator<String> onlyO3AtPosition2 =
-        (i, input, outcomes, outcome) -> i != 2 || "o3".equals(outcome);
-    SequenceValidator<String> rejectEverything =
-        (i, input, outcomes, outcome) -> false;
+    Sequence[] expected = referenceBestSequences(1, input, null,
+        new SeededContextGenerator(), nv.validator(), model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(1, input, null, new SeededContextGenerator(),
+            nv.validator());
 
-    record NamedValidator(String name, SequenceValidator<String> validator) {}
-    List<NamedValidator> validators = List.of(
-        new NamedValidator("rejectOneOutcome", rejectOneOutcome),
-        new NamedValidator("rejectAllAtPosition2", rejectAllAtPosition2),
-        new NamedValidator("onlyO3AtPosition2", onlyO3AtPosition2),
-        new NamedValidator("rejectEverything", rejectEverything));
-
-    for (NamedValidator nv : validators) {
-      for (int beam : BEAM_SIZES) {
-        for (int length : INPUT_LENGTHS) {
-          String[] input = randomInput(length, 3000L + length);
-          for (int cache : CACHE_SIZES) {
-            String desc = caseDesc("validator-" + nv.name(), beam, length, cache);
-
-            Sequence[] expected = referenceBestSequences(1, input, null,
-                new SeededContextGenerator(), nv.validator(), model, beam, cache);
-            Sequence[] actual = new BeamSearch(beam, model, cache)
-                .bestSequences(1, input, null, new SeededContextGenerator(),
-                    nv.validator());
-
-            assertSequencesEqual(expected, actual, desc);
-            if ("rejectEverything".equals(nv.name()) && length > 0) {
-              Assertions.assertEquals(0, actual.length,
-                  desc + ": reject-everything must yield an empty (non-null) array");
-              Assertions.assertEquals(0, expected.length,
-                  desc + ": reference reject-everything must also be empty");
-            }
-          }
-        }
-      }
+    assertSequencesEqual(expected, actual, desc);
+    if ("rejectEverything".equals(nv.name()) && length > 0) {
+      Assertions.assertEquals(0, actual.length,
+          desc + ": reject-everything must yield an empty (non-null) array");
+      Assertions.assertEquals(0, expected.length,
+          desc + ": reference reject-everything must also be empty");
     }
   }
 
@@ -477,34 +446,31 @@ public class BeamSearchEquivalenceTest {
   // 4. numSequences > 1: winner order and scores match the reference exactly
   // ---------------------------------------------------------------------------
 
-  @Test
-  void multiWinnerOrderingMatchesReference() {
-    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+  @ParameterizedTest(name = "len={0}, cache={1}")
+  @MethodSource("lengthCacheMatrix")
+  void multiWinnerOrderingMatchesReference(int length, int cache) {
+    MaxentModel model = model();
     int beam = 5;
     int numSequences = 3;
     Object[] additionalContext = {"ac-ctx"};
-    for (int length : INPUT_LENGTHS) {
-      String[] input = randomInput(length, 4000L + length);
-      for (int cache : CACHE_SIZES) {
-        String desc = caseDesc("multiWinner[k=3]", beam, length, cache);
+    String[] input = randomInput(length, 4000L + length);
+    String desc = caseDesc("multiWinner[k=3]", beam, length, cache);
 
-        Sequence[] expected = referenceBestSequences(numSequences, input,
-            additionalContext, new SeededContextGenerator(), ACCEPT_ALL,
-            model, beam, cache);
-        Sequence[] actual = new BeamSearch(beam, model, cache)
-            .bestSequences(numSequences, input, additionalContext,
-                new SeededContextGenerator(), ACCEPT_ALL);
+    Sequence[] expected = referenceBestSequences(numSequences, input,
+        additionalContext, new SeededContextGenerator(), ACCEPT_ALL,
+        model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(numSequences, input, additionalContext,
+            new SeededContextGenerator(), ACCEPT_ALL);
 
-        assertSequencesEqual(expected, actual, desc);
-        if (length > 0) {
-          Assertions.assertEquals(numSequences, actual.length,
-              desc + ": expected a full k-best list");
-          // Winners must come out in non-increasing score order.
-          for (int s = 1; s < actual.length; s++) {
-            Assertions.assertTrue(actual[s - 1].getScore() >= actual[s].getScore(),
-                desc + ": winner order not non-increasing at index " + s);
-          }
-        }
+    assertSequencesEqual(expected, actual, desc);
+    if (length > 0) {
+      Assertions.assertEquals(numSequences, actual.length,
+          desc + ": expected a full k-best list");
+      // Winners must come out in non-increasing score order.
+      for (int s = 1; s < actual.length; s++) {
+        Assertions.assertTrue(actual[s - 1].getScore() >= actual[s].getScore(),
+            desc + ": winner order not non-increasing at index " + s);
       }
     }
   }
@@ -521,7 +487,7 @@ public class BeamSearchEquivalenceTest {
     final int beam = 3;
     final int cache = 64;
 
-    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+    MaxentModel model = model();
     BeamSearch shared = new BeamSearch(beam, model, cache);
 
     String[][] inputs = new String[numInputs][];
@@ -603,45 +569,44 @@ public class BeamSearchEquivalenceTest {
   //    winning Sequence are consistent with the model's eval outputs
   // ---------------------------------------------------------------------------
 
-  @Test
-  void winnerMaterializationMatchesModelOutputs() {
-    MaxentModel model = new SeededModel(NUM_OUTCOMES, MODEL_SEED);
+  @ParameterizedTest(name = "cache={0}")
+  @MethodSource("cacheSizes")
+  void winnerMaterializationMatchesModelOutputs(int cache) {
+    MaxentModel model = model();
     String[] input = randomInput(7, 6000L);
     int beam = 3;
 
-    for (int cache : CACHE_SIZES) {
-      String desc = "materialization[cache=" + cache + "]";
-      BeamSearch bs = new BeamSearch(beam, model, cache);
-      Sequence winner = bs.bestSequence(input, null, new SeededContextGenerator(),
-          ACCEPT_ALL);
-      Assertions.assertNotNull(winner, desc);
-      Assertions.assertEquals(input.length, winner.getSize(), desc + ": size");
+    String desc = "materialization[cache=" + cache + "]";
+    BeamSearch bs = new BeamSearch(beam, model, cache);
+    Sequence winner = bs.bestSequence(input, null, new SeededContextGenerator(),
+        ACCEPT_ALL);
+    Assertions.assertNotNull(winner, desc);
+    Assertions.assertEquals(input.length, winner.getSize(), desc + ": size");
 
-      // The winner must equal the reference winner.
-      Sequence refWinner = referenceBestSequences(1, input, null,
-          new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache)[0];
-      Assertions.assertEquals(refWinner.getOutcomes(), winner.getOutcomes(),
-          desc + ": outcomes vs reference");
+    // The winner must equal the reference winner.
+    Sequence refWinner = referenceBestSequences(1, input, null,
+        new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache)[0];
+    Assertions.assertEquals(refWinner.getOutcomes(), winner.getOutcomes(),
+        desc + ": outcomes vs reference");
 
-      // Walk the winning path and recompute the expected probs/score independently.
-      List<String> outcomes = winner.getOutcomes();
-      double[] probs = winner.getProbs();
-      double expectedScore = 0d;
-      SeededContextGenerator cg = new SeededContextGenerator();
-      for (int i = 0; i < outcomes.size(); i++) {
-        String[] prefix = outcomes.subList(0, i).toArray(new String[0]);
-        String[] contexts = cg.getContext(i, input, prefix, new Object[0]);
-        double[] eval = model.eval(contexts);
-        int outcomeIndex = model.getIndex(outcomes.get(i));
-        Assertions.assertTrue(outcomeIndex >= 0, desc + ": outcome known to model");
-        double expectedProb = eval[outcomeIndex];
+    // Walk the winning path and recompute the expected probs/score independently.
+    List<String> outcomes = winner.getOutcomes();
+    double[] probs = winner.getProbs();
+    double expectedScore = 0d;
+    SeededContextGenerator cg = new SeededContextGenerator();
+    for (int i = 0; i < outcomes.size(); i++) {
+      String[] prefix = outcomes.subList(0, i).toArray(new String[0]);
+      String[] contexts = cg.getContext(i, input, prefix, new Object[0]);
+      double[] eval = model.eval(contexts);
+      int outcomeIndex = model.getIndex(outcomes.get(i));
+      Assertions.assertTrue(outcomeIndex >= 0, desc + ": outcome known to model");
+      double expectedProb = eval[outcomeIndex];
 
-        assertBitIdentical(expectedProb, probs[i], desc + ": getProbs()[" + i + "]");
-        assertBitIdentical(expectedProb, winner.getProb(i),
-            desc + ": getProb(" + i + ")");
-        expectedScore += StrictMath.log(expectedProb);
-      }
-      assertBitIdentical(expectedScore, winner.getScore(), desc + ": score");
+      assertBitIdentical(expectedProb, probs[i], desc + ": getProbs()[" + i + "]");
+      assertBitIdentical(expectedProb, winner.getProb(i),
+          desc + ": getProb(" + i + ")");
+      expectedScore += StrictMath.log(expectedProb);
     }
+    assertBitIdentical(expectedScore, winner.getScore(), desc + ": score");
   }
 }

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/BeamSearchTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/BeamSearchTest.java
@@ -17,7 +17,9 @@
 
 package opennlp.tools.ml;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
@@ -134,10 +136,82 @@ public class BeamSearchTest {
   }
 
   /**
+   * Uniform model: every outcome is equally probable in every context, so all
+   * candidates at a given depth tie on score exactly.
+   */
+  static class UniformModel implements MaxentModel {
+
+    private final String[] outcomes;
+
+    UniformModel(String[] outcomes) {
+      this.outcomes = outcomes;
+    }
+
+    public double[] eval(String[] context) {
+      double[] probs = new double[outcomes.length];
+      Arrays.fill(probs, 1.0d / outcomes.length);
+      return probs;
+    }
+
+    public double[] eval(String[] context, double[] probs) {
+      Arrays.fill(probs, 1.0d / outcomes.length);
+      return probs;
+    }
+
+    public double[] eval(String[] context, float[] values) {
+      return eval(context);
+    }
+
+    public String getAllOutcomes(double[] outcomes) {
+      return null;
+    }
+
+    public String getBestOutcome(double[] outcomes) {
+      return null;
+    }
+
+    public int getIndex(String outcome) {
+      return 0;
+    }
+
+    public int getNumOutcomes() {
+      return outcomes.length;
+    }
+
+    public String getOutcome(int i) {
+      return outcomes[i];
+    }
+  }
+
+  /**
+   * Tests that exact score ties resolve in a canonical outcome order rather than
+   * in whatever order the priority queue's heap layout produces.
+   */
+  @Test
+  void testBestSequencesBreakScoreTiesDeterministically() {
+    String[] sequence = {"t1", "t2"};
+    BeamSearchContextGenerator<String> cg = new IdentityFeatureGenerator(sequence);
+
+    // The model's outcome iteration order ("b" before "a") must not leak into the tie order.
+    BeamSearch bs = new BeamSearch(4, new UniformModel(new String[] {"b", "a"}));
+
+    Sequence[] best = bs.bestSequences(4, sequence, null, cg,
+        (int i, String[] inputSequence, String[] outcomesSequence,
+         String outcome) -> true);
+
+    Assertions.assertEquals(4, best.length);
+    Assertions.assertEquals(List.of("a", "a"), best[0].getOutcomes());
+    Assertions.assertEquals(List.of("a", "b"), best[1].getOutcomes());
+    Assertions.assertEquals(List.of("b", "a"), best[2].getOutcomes());
+    Assertions.assertEquals(List.of("b", "b"), best[3].getOutcomes());
+  }
+
+  /**
    * Tests finding a sequence of length one.
    */
   @Test
   void testBestSequenceOneElementInput() {
+
     String[] sequence = {"1"};
     BeamSearchContextGenerator<String> cg = new IdentityFeatureGenerator(sequence);
 

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/SeededMaxentModel.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/ml/SeededMaxentModel.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.ml;
+
+import opennlp.tools.ml.model.MaxentModel;
+
+/**
+ * A deterministic pseudo-random {@link MaxentModel} test fixture. The probability of an
+ * outcome is derived from a hash of the joined context strings, the outcome index and a
+ * fixed seed with splitmix64-style mixing, so repeated evals of the same context return
+ * identical values in (0.01, 0.99]. Values are intentionally not normalized. The
+ * {@code eval(context, probs)} buffer contract is honored: values are written into the
+ * passed array and that same array is returned. Stateless and therefore thread-safe.
+ */
+class SeededMaxentModel implements MaxentModel {
+
+  private final String[] outcomes;
+  private final long seed;
+
+  /**
+   * Initializes a {@link SeededMaxentModel} instance.
+   *
+   * @param outcomes The outcome labels; the outcome index is the array index.
+   * @param seed The seed all probabilities are derived from.
+   */
+  SeededMaxentModel(String[] outcomes, long seed) {
+    this.outcomes = outcomes;
+    this.seed = seed;
+  }
+
+  /**
+   * @return A pseudo-random probability in (0.01, 0.99], a pure function
+   *         of {@code context}, {@code outcomeIndex} and the seed.
+   */
+  private double prob(String[] context, int outcomeIndex) {
+    long h = seed;
+    for (String c : context) {
+      h = mix(h, c.hashCode());
+    }
+    h = mix(h, outcomeIndex);
+    // splitmix64 finalizer for avalanche
+    h ^= h >>> 30;
+    h *= 0xBF58476D1CE4E5B9L;
+    h ^= h >>> 27;
+    h *= 0x94D049BB133111EBL;
+    h ^= h >>> 31;
+    double u = (h >>> 11) * (1.0 / (1L << 53)); // [0, 1)
+    return 0.01 + 0.98 * u; // (0.01, 0.99]
+  }
+
+  /**
+   * @return {@code h} combined with {@code v} FNV-style.
+   */
+  private static long mix(long h, long v) {
+    return (h ^ (v + 0x9E3779B97F4A7C15L)) * 0x100000001B3L;
+  }
+
+  @Override
+  public double[] eval(String[] context) {
+    return eval(context, new double[outcomes.length]);
+  }
+
+  @Override
+  public double[] eval(String[] context, double[] probs) {
+    for (int i = 0; i < outcomes.length; i++) {
+      probs[i] = prob(context, i);
+    }
+    return probs; // buffer contract: write into the passed array AND return it
+  }
+
+  @Override
+  public double[] eval(String[] context, float[] values) {
+    return eval(context);
+  }
+
+  @Override
+  public String getOutcome(int i) {
+    return outcomes[i];
+  }
+
+  @Override
+  public int getNumOutcomes() {
+    return outcomes.length;
+  }
+
+  @Override
+  public String getAllOutcomes(double[] outcomes) {
+    return null;
+  }
+
+  @Override
+  public String getBestOutcome(double[] outcomes) {
+    return null;
+  }
+
+  @Override
+  public int getIndex(String outcome) {
+    for (int i = 0; i < outcomes.length; i++) {
+      if (outcomes[i].equals(outcome)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}


### PR DESCRIPTION
## Problem

`BeamSearch.bestSequences` performs O(beamSize × numOutcomes × n²) element copies per document (object count is O(beam × numOutcomes × n)):

1. Every candidate expansion (`new Sequence(top, out, p)`) copies the parent's entire `outcomes` and `probs` lists (`Sequence.java`).
2. Every pop copies them again via `Sequence.getOutcomes()` (`List.copyOf`, added in OPENNLP-1340) followed by `toArray()`.

For a 215-token chunk with beam 3 and 3 outcomes that is ~550k element copies per document per model. This churn is invisible single-threaded but saturates memory write bandwidth under concurrency: throughput plateaus at ~5.8x on a 24-core run regardless of offered concurrency (12 vs 32 threads yield the same docs/s), and splitting work across independent processes degrades per-core efficiency by ~55% — the contended resource is below the process (the memory bus), not any lock (lock profiling shows zero contention; GC pauses are ~2 ms).

The copying dates to the original 2010 beam-search import; OPENNLP-1340 (2023) added the `List.copyOf` on top. It only becomes a *scaling* ceiling now that OPENNLP-1816 makes shared ME instances across threads practical.

## Fix

Replace the per-candidate `Sequence` copies with a private immutable `SearchNode` chain inside `bestSequences`:

- Child expansion becomes O(1) (parent link + outcome + prob instead of copying two lists).
- The outcome array for context generation is built from the chain when needed; `outcomes()` allocates a fresh array on each call.
- Only the winning sequences are converted to public `Sequence` objects, via `Sequence.add` which accumulates `score += StrictMath.log(p)` in the same order — bit-identical scores.
- `compareTo` mirrors `Sequence.compareTo` exactly, so `PriorityQueue` behavior is unchanged.

No public API changes; one file changed in production code (`BeamSearch.java`, +80/−13).

## Correctness evidence

`BeamSearchEquivalenceTest` ports the pre-refactor algorithm inline as a reference and asserts bit-identical behavior (outcome order, scores, per-position probs via `doubleToRawLongBits`):

- 372 seeded combinations: 5 beam sizes × 6 input lengths × 2 cache settings, tight `minSequenceScore` thresholds, restrictive validators (including the `next.isEmpty()` fallback and reject-everything), k-best winner ordering.
- 384 concurrent decode verifications (8 threads, shared instance) vs serial reference.
- Existing suites green: `BeamSearchTest`, namefind / postag / chunker / lemmatizer (112 tests).
- Independent real-world check: span output of `NameFinderME` (en-ner-person) bit-identical serial vs concurrent over ~10k real documents (~215 tokens each), on x86 and aarch64.

## Performance evidence

`BeamSearchBenchmark` (JMH, synthetic deterministic model, isolates the sequence mechanics; only public API, so the same class runs against both implementations — baseline = pre-refactor jar):

| sequenceLength | pre 24T | post 24T | ratio |
|---------------:|--------:|---------:|------:|
| 8 | 1.40M ops/s | 3.16M ops/s | 2.3x |
| 64 | 67.5k ops/s | 297k ops/s | 4.4x |
| 256 | 5,491 ops/s | 50,176 ops/s | 9.1x |

Pre-refactor scaling on 24 threads collapses with sequence length (6.2x → 2.5x); post-refactor scaling grows (7.0x → 11.5x).

Real-model measurements (`NameFinderME`, en-ner-person, shared instance, 1.3 KB docs):

- 24 pinned x86 cores: saturation throughput 5,609 → 12,304 docs/s (+119%); plateau knee moves from ~12 threads to ~20+.
- 8 pinned x86 cores: 8-thread scaling 4.69x → 7.05x.
- 4-core ARM (Pi 5): allocation per document −59%, saturated throughput ~2x (435 → 864 docs/s).
- Single-thread is roughly neutral on x86 (−2…−4%) and ~+27% on ARM.

Full methodology and the JMH table are in `opennlp-core/opennlp-runtime/BENCHMARKS.md`.

## Notes for reviewers

- The per-thread `CacheState` (contexts cache, score buffers) is untouched; thread-safety contract from OPENNLP-1816 is preserved.
- `Sequence` is deliberately not modified; the chain exists only inside the search.

