### PR TITLE
OPENNLP-1904: Default-locale case folding corrupts lemmatizer models and output

### DIFF
--- a/opennlp-api/src/main/java/opennlp/tools/util/StringUtil.java
+++ b/opennlp-api/src/main/java/opennlp/tools/util/StringUtil.java
@@ -20,6 +20,7 @@ package opennlp.tools.util;
 import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -485,8 +486,8 @@ public class StringUtil {
    * @return Retrieves the Shortest Edit Script (SES) required to go from a word to a lemma.
    */
   public static String getShortestEditScript(String wordForm, String lemma) {
-    String reversedWF = new StringBuffer(wordForm.toLowerCase()).reverse().toString();
-    String reversedLemma = new StringBuffer(lemma.toLowerCase()).reverse().toString();
+    String reversedWF = new StringBuffer(wordForm.toLowerCase(Locale.ROOT)).reverse().toString();
+    String reversedLemma = new StringBuffer(lemma.toLowerCase(Locale.ROOT)).reverse().toString();
     StringBuffer permutations = new StringBuffer();
     String ses;
     if (!reversedWF.equals(reversedLemma)) {

--- a/opennlp-api/src/test/java/opennlp/tools/util/StringUtilLocaleTest.java
+++ b/opennlp-api/src/test/java/opennlp/tools/util/StringUtilLocaleTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.util;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the {@link StringUtil} operations feeding the lemmatizer's shortest edit script
+ * are independent of the JVM's default {@link Locale}.
+ */
+public class StringUtilLocaleTest {
+
+  /**
+   * Turkish folds {@code 'I'} to the dotless {@code 'ı'} (U+0131) instead of {@code 'i'},
+   * which makes it the canonical probe for an unqualified {@code String#toLowerCase()}.
+   */
+  private static final Locale TURKISH = Locale.of("tr", "TR");
+
+  private final Locale defaultLocale = Locale.getDefault();
+
+  @AfterEach
+  void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
+  }
+
+  /**
+   * The shortest edit script becomes an outcome label inside a trained lemmatizer model.
+   * If it varied with the default locale, a model trained on a Turkish JVM would carry
+   * labels no other JVM could reproduce.
+   */
+  @Test
+  void testGetShortestEditScriptIsIndependentOfDefaultLocale() {
+    Locale.setDefault(TURKISH);
+
+    Assertions.assertEquals("D0s", StringUtil.getShortestEditScript("IMPORTS", "import"));
+    Assertions.assertEquals("R2ioR1cuI1s", StringUtil.getShortestEditScript("MICE", "mouse"));
+    Assertions.assertEquals("D3iD2cR0sx", StringUtil.getShortestEditScript("INDICES", "index"));
+    Assertions.assertEquals("O", StringUtil.getShortestEditScript("Illinois", "illinois"));
+  }
+
+  /**
+   * Guards the choice of {@link Locale#ROOT} over the code point based
+   * {@link StringUtil#toLowerCase(CharSequence)}: the two disagree on context sensitive
+   * mappings such as the Greek final sigma. Existing models were trained with
+   * {@link Locale#ROOT} semantics, so only {@link Locale#ROOT} keeps them readable.
+   */
+  @Test
+  void testGetShortestEditScriptUsesRootFoldingNotCodePointFolding() {
+    // Locale.ROOT maps the trailing capital sigma to the final form 'ς', so both inputs
+    // fold to the same string and no edit is required.
+    Assertions.assertEquals("O", StringUtil.getShortestEditScript("ΟΔΟΣ",
+        "οδος"));
+
+    // Character#toLowerCase is context free and would yield the non final 'σ' instead,
+    // which is a different string and hence a different, model breaking outcome label.
+    Assertions.assertNotEquals("οδος",
+        StringUtil.toLowerCase("ΟΔΟΣ"));
+  }
+}

--- a/opennlp-core/opennlp-cli/src/main/java/opennlp/tools/cmdline/DetailedFMeasureListener.java
+++ b/opennlp-core/opennlp-cli/src/main/java/opennlp/tools/cmdline/DetailedFMeasureListener.java
@@ -116,7 +116,7 @@ public abstract class DetailedFMeasureListener<T> implements EvaluationMonitor<T
       + " [target: %3d; tp: %3d; fp: %3d]";
 
   public String createReport() {
-    return createReport(Locale.getDefault());
+    return createReport(Locale.ROOT);
   }
 
   public String createReport(Locale locale) {

--- a/opennlp-core/opennlp-cli/src/main/java/opennlp/tools/cmdline/FineGrainedReportListener.java
+++ b/opennlp-core/opennlp-cli/src/main/java/opennlp/tools/cmdline/FineGrainedReportListener.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -163,6 +164,19 @@ public abstract class FineGrainedReportListener {
     return stats.getConfusionMatrixTagset(token);
   }
 
+  /**
+   * Applies a {@link MessageFormat} number pattern using {@link Locale#ROOT}, so that the
+   * figures in a report stay identical regardless of the JVM's default {@link Locale}.
+   *
+   * @param pattern The {@link MessageFormat} pattern to apply.
+   * @param value The value to format.
+   *
+   * @return The formatted value.
+   */
+  private static String formatNumber(String pattern, Object value) {
+    return new MessageFormat(pattern, Locale.ROOT).format(new Object[] {value});
+  }
+
   private double[][] getConfusionMatrix() {
     return stats.getConfusionMatrix();
   }
@@ -187,7 +201,7 @@ public abstract class FineGrainedReportListener {
           minColumnSize = matrix[i][j].length();
         }
       }
-      matrix[i][j] = MessageFormat.format("{0,number,#.##%}", data[i][j]);
+      matrix[i][j] = formatNumber("{0,number,#.##%}", data[i][j]);
       if (data[i][j] == 1 && filter) {
         initialIndex = i + 1;
       }
@@ -229,12 +243,12 @@ public abstract class FineGrainedReportListener {
         String.format("%21s: %6s", "Max sentence size", getMaxSentenceSize())).append("\n");
     printStream.append(
         String.format("%21s: %6s", "Average sentence size",
-            MessageFormat.format("{0,number,#.##}", getAverageSentenceSize()))).append("\n");
+            formatNumber("{0,number,#.##}", getAverageSentenceSize()))).append("\n");
     printStream.append(
         String.format("%21s: %6s", "Tags count", getNumberOfTags())).append("\n");
     printStream.append(
         String.format("%21s: %6s", "Accuracy",
-            MessageFormat.format("{0,number,#.##%}", getAccuracy()))).append("\n");
+            formatNumber("{0,number,#.##%}", getAccuracy()))).append("\n");
     printFooter("Evaluation Corpus Statistics");
   }
 
@@ -308,7 +322,7 @@ public abstract class FineGrainedReportListener {
       String tok = tokIterator.next();
       int ocurrencies = getTokenFrequency(tok);
       int errors = getTokenErrors(tok);
-      String rate = MessageFormat.format("{0,number,#.##%}", (double) errors
+      String rate = formatNumber("{0,number,#.##%}", (double) errors
           / ocurrencies);
 
       printStream.append(String.format(format, tok, errors, ocurrencies, rate)
@@ -347,7 +361,7 @@ public abstract class FineGrainedReportListener {
     for (String tag : tags) {
       int ocurrencies = getTagFrequency(tag);
       int errors = getTagErrors(tag);
-      String rate = MessageFormat.format("{0,number,#.###}", (double) errors
+      String rate = formatNumber("{0,number,#.###}", (double) errors
           / ocurrencies);
 
       double p = getTagPrecision(tag);
@@ -355,9 +369,9 @@ public abstract class FineGrainedReportListener {
       double f = getTagFMeasure(tag);
 
       printStream.append(String.format(format, tag, errors, ocurrencies, rate,
-          MessageFormat.format("{0,number,#.###}", p > 0 ? p : 0),
-          MessageFormat.format("{0,number,#.###}", r > 0 ? r : 0),
-          MessageFormat.format("{0,number,#.###}", f > 0 ? f : 0))
+          formatNumber("{0,number,#.###}", p > 0 ? p : 0),
+          formatNumber("{0,number,#.###}", r > 0 ? r : 0),
+          formatNumber("{0,number,#.###}", f > 0 ? f : 0))
 
       );
     }
@@ -405,7 +419,7 @@ public abstract class FineGrainedReportListener {
             .append("]\n")
             .append(
                 String.format("%12s: %-8s", "Accuracy",
-                    MessageFormat.format("{0,number,#.##%}", acc)))
+                    formatNumber("{0,number,#.##%}", acc)))
             .append("\n");
         printStream.append(
             String.format("%12s: %-8s", "Ocurrencies",

--- a/opennlp-core/opennlp-cli/src/test/java/opennlp/tools/cmdline/FineGrainedReportListenerTest.java
+++ b/opennlp-core/opennlp-cli/src/test/java/opennlp/tools/cmdline/FineGrainedReportListenerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.cmdline;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import opennlp.tools.cmdline.postag.POSTaggerFineGrainedReportListener;
+import opennlp.tools.postag.POSSample;
+
+/**
+ * Tests that the figures written by a {@link FineGrainedReportListener} do not change with
+ * the JVM's default {@link Locale}.
+ */
+public class FineGrainedReportListenerTest {
+
+  private final Locale defaultLocale = Locale.getDefault();
+
+  @AfterEach
+  void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
+  }
+
+  @Test
+  void testReportIsIndependentOfDefaultLocale() throws Exception {
+    Locale.setDefault(Locale.GERMANY);
+
+    final String report = createReport();
+
+    // Two out of three tags are correct. A locale with a comma decimal separator would
+    // render this as "66,67%" and change every figure in the report along with it.
+    Assertions.assertTrue(report.contains("66.67%"),
+        () -> "Report should contain the Locale.ROOT rendering of the accuracy:\n" + report);
+    Assertions.assertFalse(report.contains("66,67%"),
+        () -> "Report should not render figures with the default locale:\n" + report);
+  }
+
+  private static String createReport() throws Exception {
+    final String[] sentence = {"He", "runs", "fast"};
+    final POSSample reference = new POSSample(sentence, new String[] {"PRP", "VBZ", "RB"});
+    final POSSample prediction = new POSSample(sentence, new String[] {"PRP", "VBZ", "JJ"});
+
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      final POSTaggerFineGrainedReportListener listener =
+          new POSTaggerFineGrainedReportListener(out);
+      listener.misclassified(reference, prediction);
+      listener.writeReport();
+      return out.toString(StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/model/AbstractModel.java
+++ b/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/ml/model/AbstractModel.java
@@ -18,8 +18,10 @@
 package opennlp.tools.ml.model;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -31,7 +33,8 @@ import opennlp.tools.ml.ArrayMath;
  */
 public abstract class AbstractModel implements MaxentModel {
 
-  private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0000");
+  private static final DecimalFormat DECIMAL_FORMAT =
+      new DecimalFormat("0.0000", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
   /** Mapping between predicates/contexts and an integer representing them. */
   protected Map<String, Context> pmap;

--- a/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/util/TrainingParameters.java
+++ b/opennlp-core/opennlp-ml/opennlp-ml-commons/src/main/java/opennlp/tools/util/TrainingParameters.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -329,12 +330,12 @@ public class TrainingParameters implements Parameters {
     mlParams.put(Parameters.ALGORITHM_PARAM , "MAXENT");
     mlParams.put(Parameters.TRAINER_TYPE_PARAM , EventTrainer.EVENT_VALUE);
     mlParams.put(Parameters.ITERATIONS_PARAM ,
-        null != getIntParameter("-" + Parameters.ITERATIONS_PARAM.toLowerCase() , params) ?
-            getIntParameter("-" + Parameters.ITERATIONS_PARAM.toLowerCase() , params) :
+        null != getIntParameter("-" + Parameters.ITERATIONS_PARAM.toLowerCase(Locale.ROOT) , params) ?
+            getIntParameter("-" + Parameters.ITERATIONS_PARAM.toLowerCase(Locale.ROOT) , params) :
             Parameters.ITERATIONS_DEFAULT_VALUE);
     mlParams.put(Parameters.CUTOFF_PARAM ,
-        null != getIntParameter("-" + Parameters.CUTOFF_PARAM.toLowerCase() , params) ?
-            getIntParameter("-" + Parameters.CUTOFF_PARAM.toLowerCase() , params) :
+        null != getIntParameter("-" + Parameters.CUTOFF_PARAM.toLowerCase(Locale.ROOT) , params) ?
+            getIntParameter("-" + Parameters.CUTOFF_PARAM.toLowerCase(Locale.ROOT) , params) :
             Parameters.CUTOFF_DEFAULT_VALUE);
 
     return mlParams;

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/lemmatizer/DictionaryLemmatizer.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/lemmatizer/DictionaryLemmatizer.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -161,7 +162,7 @@ public class DictionaryLemmatizer implements Lemmatizer {
    * @return Retrieves the dictionary keys (word and postag).
    */
   private List<String> getDictKeys(final String word, final String postag) {
-    return new ArrayList<>(Arrays.asList(word.toLowerCase(), postag));
+    return new ArrayList<>(Arrays.asList(word.toLowerCase(Locale.ROOT), postag));
   }
 
 

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/lemmatizer/LemmatizerME.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/lemmatizer/LemmatizerME.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import opennlp.tools.commons.ThreadSafe;
@@ -168,7 +169,7 @@ public class LemmatizerME implements Lemmatizer, Probabilistic {
   public static String[] decodeLemmas(String[] toks, String[] preds) {
     List<String> lemmas = new ArrayList<>();
     for (int i = 0; i < toks.length; i++) {
-      String lemma = StringUtil.decodeShortestEditScript(toks[i].toLowerCase(), preds[i]);
+      String lemma = StringUtil.decodeShortestEditScript(toks[i].toLowerCase(Locale.ROOT), preds[i]);
       if (lemma.length() == 0) {
         lemma = "_";
       }

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/lemmatizer/DictionaryLemmatizerTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/lemmatizer/DictionaryLemmatizerTest.java
@@ -17,13 +17,25 @@
 
 package opennlp.tools.lemmatizer;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class DictionaryLemmatizerTest {
 
+  /**
+   * Turkish folds {@code 'I'} to the dotless {@code 'ı'} (U+0131) instead of {@code 'i'}.
+   */
+  private static final Locale TURKISH = Locale.of("tr", "TR");
+
   private static DictionaryLemmatizer dictionaryLemmatizer;
+
+  private final Locale defaultLocale = Locale.getDefault();
 
   @BeforeAll
   static void loadDictionary() throws Exception {
@@ -47,6 +59,27 @@ public class DictionaryLemmatizerTest {
         Assertions.assertEquals(expectedLemma[i], actualLemma[i]);
       }
     }
+  }
+
+  @AfterEach
+  void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
+  }
+
+  /**
+   * The dictionary is read verbatim but looked up folded, so the fold has to match the
+   * casing of the dictionary file rather than whatever locale the JVM happens to run in.
+   */
+  @Test
+  void testLookupIsIndependentOfDefaultLocale() throws Exception {
+    final String entries = "illinois\tNNP\tIllinois\n" + "indices\tNNS\tindex\n";
+    final DictionaryLemmatizer lemmatizer = new DictionaryLemmatizer(
+        new ByteArrayInputStream(entries.getBytes(StandardCharsets.UTF_8)));
+
+    Locale.setDefault(TURKISH);
+
+    Assertions.assertArrayEquals(new String[] {"Illinois", "index"},
+        lemmatizer.lemmatize(new String[] {"Illinois", "INDICES"}, new String[] {"NNP", "NNS"}));
   }
 
 }

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/lemmatizer/LemmatizerMELocaleTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/lemmatizer/LemmatizerMELocaleTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.lemmatizer;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the lemma class encoding and decoding of {@link LemmatizerME} do not depend
+ * on the JVM's default {@link Locale}.
+ * <p>
+ * Encoding produces the outcome labels that are persisted in a trained model, decoding
+ * consumes them at inference time. Both sides therefore have to agree across JVMs.
+ */
+public class LemmatizerMELocaleTest {
+
+  /**
+   * Turkish folds {@code 'I'} to the dotless {@code 'ı'} (U+0131) instead of {@code 'i'}.
+   */
+  private static final Locale TURKISH = Locale.of("tr", "TR");
+
+  private static final String[] TOKENS = {"MICE", "INDICES"};
+  private static final String[] LEMMAS = {"mouse", "index"};
+
+  /** The lemma classes an existing, English trained model contains for {@link #TOKENS}. */
+  private static final String[] LEMMA_CLASSES = {"R2ioR1cuI1s", "D3iD2cR0sx"};
+
+  private final Locale defaultLocale = Locale.getDefault();
+
+  @AfterEach
+  void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
+  }
+
+  /**
+   * Training on a Turkish JVM must not write different outcome labels into the model.
+   */
+  @Test
+  void testEncodeLemmasIsIndependentOfDefaultLocale() {
+    Locale.setDefault(TURKISH);
+
+    Assertions.assertArrayEquals(LEMMA_CLASSES, LemmatizerME.encodeLemmas(TOKENS, LEMMAS));
+  }
+
+  /**
+   * Serving an existing model on a Turkish JVM must not corrupt the reconstructed lemmas.
+   */
+  @Test
+  void testDecodeLemmasIsIndependentOfDefaultLocale() {
+    Locale.setDefault(TURKISH);
+
+    Assertions.assertArrayEquals(LEMMAS, LemmatizerME.decodeLemmas(TOKENS, LEMMA_CLASSES));
+  }
+}

--- a/opennlp-tools/src/test/java/opennlp/tools/chunker/ChunkerDetailedFMeasureListenerTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/chunker/ChunkerDetailedFMeasureListenerTest.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +32,13 @@ import opennlp.tools.formats.ResourceAsStreamFactory;
 import opennlp.tools.util.PlainTextByLineStream;
 
 public class ChunkerDetailedFMeasureListenerTest {
+
+  private final Locale defaultLocale = Locale.getDefault();
+
+  @AfterEach
+  void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
+  }
 
   @Test
   void testEvaluator() throws IOException {
@@ -67,5 +75,34 @@ public class ChunkerDetailedFMeasureListenerTest {
     }
 
     Assertions.assertEquals(expected.toString().trim(), listener.createReport(Locale.ENGLISH).trim());
+  }
+
+  /**
+   * The no-argument report has to render the same figures everywhere, so a JVM defaulting to
+   * a locale with a comma decimal separator must not change the numbers in the output.
+   */
+  @Test
+  void testReportIsIndependentOfDefaultLocale() throws IOException {
+    ChunkerDetailedFMeasureListener listener = new ChunkerDetailedFMeasureListener();
+    evaluate(listener);
+
+    Locale.setDefault(Locale.GERMANY);
+
+    Assertions.assertEquals(listener.createReport(Locale.ENGLISH).trim(),
+        listener.createReport().trim());
+  }
+
+  private static void evaluate(ChunkerDetailedFMeasureListener listener) throws IOException {
+    ResourceAsStreamFactory inPredicted = new ResourceAsStreamFactory(
+        ChunkerDetailedFMeasureListenerTest.class, "/opennlp/tools/chunker/output.txt");
+    ResourceAsStreamFactory inExpected = new ResourceAsStreamFactory(
+        ChunkerDetailedFMeasureListenerTest.class, "/opennlp/tools/chunker/output.txt");
+
+    DummyChunkSampleStream predictedSample = new DummyChunkSampleStream(
+        new PlainTextByLineStream(inPredicted, StandardCharsets.UTF_8), true);
+    DummyChunkSampleStream expectedSample = new DummyChunkSampleStream(
+        new PlainTextByLineStream(inExpected, StandardCharsets.UTF_8), false);
+
+    new ChunkerEvaluator(new DummyChunker(predictedSample), listener).evaluate(expectedSample);
   }
 }

--- a/opennlp-tools/src/test/java/opennlp/tools/util/TrainingParametersTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/util/TrainingParametersTest.java
@@ -19,14 +19,28 @@ package opennlp.tools.util;
 
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import opennlp.tools.ml.EventTrainer;
 
 public class TrainingParametersTest {
+
+  /**
+   * Turkish folds {@code 'I'} to the dotless {@code 'ı'} (U+0131) instead of {@code 'i'}.
+   */
+  private static final Locale TURKISH = Locale.of("tr", "TR");
+
+  private final Locale defaultLocale = Locale.getDefault();
+
+  @AfterEach
+  void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
+  }
 
   @Test
   void testConstructors() throws Exception {
@@ -117,6 +131,28 @@ public class TrainingParametersTest {
 
     Assertions.assertEquals("MAXENT" , tr.algorithm());
     Assertions.assertEquals(100 ,
+        tr.getIntParameter(Parameters.ITERATIONS_PARAM ,
+            Parameters.ITERATIONS_DEFAULT_VALUE));
+    Assertions.assertEquals(10 ,
+        tr.getIntParameter(Parameters.CUTOFF_PARAM ,
+            Parameters.CUTOFF_DEFAULT_VALUE));
+  }
+
+  /**
+   * The switch names are derived by folding the parameter constants, which start with a
+   * capital {@code 'I'} respectively {@code 'C'}. Folding them with the default locale makes
+   * a Turkish JVM look for {@code "-\u0131terations"} and silently train with the defaults.
+   */
+  @Test
+  public void testSetParamsIsIndependentOfDefaultLocale() {
+    String[] args =
+        { "-model" , "en-token-test.bin" , "-lang" , "en" , "-data" ,
+            "en-token.train" , "-encoding" , "UTF-8" , "-cutoff" , "10" , "-iterations" , "50" };
+
+    Locale.setDefault(TURKISH);
+    TrainingParameters tr = TrainingParameters.setParams(args);
+
+    Assertions.assertEquals(50 ,
         tr.getIntParameter(Parameters.ITERATIONS_PARAM ,
             Parameters.ITERATIONS_DEFAULT_VALUE));
     Assertions.assertEquals(10 ,


### PR DESCRIPTION
Fixes the sites listed in OPENNLP-1904.

Several code paths fold case with the JVM default locale. In the lemmatizer this is not cosmetic: the folded strings become shortest-edit-script labels that `encodeLemmas` writes **into the trained model**, and `decodeLemmas` folds again with whatever locale the consumer runs under. A model trained on a Turkish JVM carries labels no other machine reproduces, and an English-trained model emits corrupted lemmas when served on one. Nothing logs and nothing throws.

### Reproduction

Assertion failures observed against unfixed code, under `Locale.setDefault` of `tr` (or `de_DE` for the report cases):

```
LemmatizerME.decodeLemmas          expected <mouse>       but was <mıuse>
StringUtil.getShortestEditScript   expected <D0s>         but was <R6ıiD0s>
LemmatizerME.encodeLemmas          expected <R2ioR1cuI1s> but was <R2ıoR1cuI1s>
DictionaryLemmatizer               expected <Illinois>    but was <O>
TrainingParameters.setParams       expected <50>          but was <100>
```

The last one is a separate user-visible bug in the same family: `setParams` computes the flag name as `"Iterations".toLowerCase()`, which under `tr` yields `-ıterations`, so `TokenizerTrainerTool` silently ignores `-iterations` and trains with the default.

### Why `Locale.ROOT` and not `StringUtil.toLowerCase`

This is the load-bearing decision and the likely review question.

`StringUtil.toLowerCase` maps code points through `Character.toLowerCase`. That is context free and disagrees with `String.toLowerCase(Locale.ROOT)` on context-sensitive mappings (Greek final sigma: `ΟΔΟΣ` folds to `οδοσ` rather than `οδος`) and on one-to-many mappings such as `ß`.

`String.toLowerCase()` without a locale diverges from `Locale.ROOT` only under `tr` / `az` (dotted/dotless I) and `lt` (retained dot). Everywhere else this change is a no-op. Portable models (including every shipped artifact produced on an English-locale JVM) need no regeneration.

Models trained and served only on a tr/az/lt default locale were already non-portable; after this change those SES labels need a retrain. That surfaces existing breakage rather than causing it.

`StringUtilLocaleTest` carries a guard that fails if this is later switched to the code-point fold for consistency.

### Behaviour change for release notes

`DetailedFMeasureListener.createReport()` and `FineGrainedReportListener` now always render with `Locale.ROOT`, so CLI eval report output is no longer localized. This was chosen so reports are reproducible, diffable and machine-parseable across machines. The explicit `createReport(Locale)` overload is untouched for callers who want localization.

### Tests

There was no locale test coverage anywhere in the tree before this: no `Locale.setDefault` in main or test sources. Each new test was verified to fail before the fix and pass after.

Two gaps, both deliberate:

- `AbstractModel.DECIMAL_FORMAT` is fixed without a red/green test. The formatter is a `static final` resolved at class initialization, so a `setDefault` test passes both before and after and proves nothing.
- `StringUtilLocaleTest.testGetShortestEditScriptUsesRootFoldingNotCodePointFolding` is a guard, not a regression test. It passes before and after; its purpose is to break on a future change.

Note for anyone adding more: the root `pom.xml` surefire `argLine`s do not forward `-Duser.language`, so `mvn -Duser.language=tr test` does not reach the forked test JVM.

Full 23-module reactor: BUILD SUCCESS, zero failures, with checkstyle, rat and forbiddenapis active.

