### PR TITLE
OPENNLP-1913: Include Maven Wrapper configuration in source release

### DIFF
--- a/opennlp-distr/src/main/assembly/src.xml
+++ b/opennlp-distr/src/main/assembly/src.xml
@@ -34,5 +34,12 @@
         <exclude>**/release.properties</exclude>
       </excludes>
     </fileSet>
+    <!-- OPENNLP-1913: The Maven Wrapper configuration lives in a hidden directory and would
+         be dropped by the '**/.*/**' exclude above. Without it, './mvnw' cannot be used to
+         build from a source release. -->
+    <fileSet>
+      <directory>../.mvn</directory>
+      <outputDirectory>.mvn</outputDirectory>
+    </fileSet>
   </fileSets>
 </assembly>


### PR DESCRIPTION
The `**/.*/**` exclude dropped `.mvn/wrapper/maven-wrapper.properties` from the source assembly, so `./mvnw` could not be used to build from a source release.