### PR TITLE
OPENNLP-1902: Verify cached models against their SHA-512 checksum

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -148,10 +148,12 @@ JVM arguments, or the `OPENNLP_MAX_ENTRIES` setting.
 CDN (`https://dlcdn.apache.org/opennlp/`) and verifies each download against the
 published SHA-512 checksum before use. A mismatch fails the load.
 
-Note that verification happens at **download** time. A model already present in
-the local download cache is currently not re-verified when it is loaded again, so
-treat the cache directory (`~/.opennlp` by default) as trusted storage and protect
-it accordingly.
+The published checksum is stored next to the model in the download cache, and a
+model already present in that cache is re-verified against it on every load. This
+check is performed locally and does not contact the CDN again. A cache entry
+written by an OpenNLP version that predates this behaviour has no stored checksum;
+for those the published checksum is fetched once and then stored, and if it cannot
+be retrieved the model is loaded and a warning is logged.
 
 The base URL can be overridden with the `OPENNLP_DOWNLOAD_BASE_URL` system
 property. That property is **operator configuration**. Pointing it at a host you

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -155,6 +155,9 @@ written by an OpenNLP version that predates this behaviour has no stored checksu
 for those the published checksum is fetched once and then stored, and if it cannot
 be retrieved the model is loaded and a warning is logged.
 
+Treat the cache directory (`~/.opennlp` by default) as trusted storage and protect
+it accordingly.
+
 The base URL can be overridden with the `OPENNLP_DOWNLOAD_BASE_URL` system
 property. That property is **operator configuration**. Pointing it at a host you
 do not control, and then receiving a malicious model, is not a vulnerability in

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/DownloadUtil.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/util/DownloadUtil.java
@@ -62,6 +62,7 @@ public class DownloadUtil {
   private static final String MODEL_URI_PATH =
       System.getProperty("OPENNLP_DOWNLOAD_MODEL_PATH", "models/ud-models-1.3/");
   private static final String OPENNLP_DOWNLOAD_HOME = "OPENNLP_DOWNLOAD_HOME";
+  private static final String CHECKSUM_EXTENSION = ".sha512";
 
   private static Map<String, Map<ModelType, URL>> availableModels;
 
@@ -89,7 +90,7 @@ public class DownloadUtil {
         boolean exists;
         if (Files.exists(localFile)) {
           // if this does not throw the requested model is valid!
-          validateModel(url + ".sha512", localFile);
+          validateCachedModel(url + CHECKSUM_EXTENSION, localFile);
           exists = true;
         } else {
           exists = false;
@@ -130,7 +131,8 @@ public class DownloadUtil {
    * The model is saved to an {@code .opennlp/} directory
    * located in the user's home directory. This directory will be created
    * if it does not already exist. If a model to be downloaded already
-   * exists in that directory, the model will not be re-downloaded.
+   * exists in that directory, the model will not be re-downloaded, but it is
+   * verified against its SHA-512 checksum before it is loaded.
    *
    * @param url  The model's {@link URL}.
    * @param type The class of the resulting model {@link T}.
@@ -159,10 +161,11 @@ public class DownloadUtil {
       try (final InputStream in = url.openStream()) {
         Files.copy(in, localFile, StandardCopyOption.REPLACE_EXISTING);
       }
-      validateModel(url + ".sha512", localFile);
+      validateModel(url + CHECKSUM_EXTENSION, localFile);
       logger.debug("Download complete.");
     } else {
       logger.debug("Model file '{}' already exists. Skipping download.", filename);
+      validateCachedModel(url + CHECKSUM_EXTENSION, localFile);
     }
 
     try {
@@ -185,35 +188,106 @@ public class DownloadUtil {
   }
 
   /**
-   * Validates a downloaded model via the specified {@link Path downloadedModel path}.
+   * Validates a freshly downloaded model via the specified {@link Path downloadedModel path}
+   * and stores the expected checksum next to it, so that subsequent loads of the cached file
+   * can be verified without contacting the CDN again.
    *
    * @param sha512          the url to get the sha512 hash
    * @param downloadedModel the model file to check
-   * @throws IOException thrown if the checksum could not be computed
+   * @throws IOException thrown if the checksum could not be computed or did not match
    */
   private static void validateModel(String sha512, Path downloadedModel) throws IOException {
-    String expectedChecksum;
+    final String checksumFile = downloadChecksumFile(sha512, downloadedModel);
+    verifyChecksum(downloadedModel, parseChecksum(checksumFile));
+    storeChecksumFile(downloadedModel, checksumFile);
+  }
+
+  /**
+   * Validates a model that is already present in the download home.
+   * <p>
+   * The expected checksum stored by a previous download is used, so no network access is
+   * required on this path. When no checksum was stored - the download home was populated by
+   * an OpenNLP version that predates this check - the published checksum is fetched once and
+   * then stored. If it cannot be retrieved, the model is loaded and a warning is logged,
+   * which preserves the behaviour of those earlier versions for offline environments.
+   *
+   * @param sha512      the url to get the sha512 hash
+   * @param cachedModel the cached model file to check
+   * @throws IOException thrown if the checksum could not be computed or did not match
+   */
+  private static void validateCachedModel(String sha512, Path cachedModel) throws IOException {
+    final Path checksumFile = checksumPathFor(cachedModel);
+
+    if (Files.exists(checksumFile)) {
+      verifyChecksum(cachedModel, parseChecksum(Files.readString(checksumFile, StandardCharsets.UTF_8)));
+      return;
+    }
+
+    final String publishedChecksumFile;
+    try {
+      publishedChecksumFile = downloadChecksumFile(sha512, cachedModel);
+    } catch (IOException e) {
+      logger.warn("Could not retrieve the expected checksum for cached model '{}'. "
+          + "Its integrity has not been verified.", cachedModel.getFileName(), e);
+      return;
+    }
+
+    verifyChecksum(cachedModel, parseChecksum(publishedChecksumFile));
+    storeChecksumFile(cachedModel, publishedChecksumFile);
+  }
+
+  /**
+   * Retrieves the published {@code ".sha512"} file. Its content is returned unmodified so that
+   * the copy stored next to the model stays interchangeable with the published one.
+   */
+  private static String downloadChecksumFile(String sha512, Path model) throws IOException {
     try {
       // Download SHA512 checksum file
       final URL hashSum = new URI(sha512).toURL();
       try (BufferedReader reader = new BufferedReader(new InputStreamReader(hashSum.openStream()))) {
-        expectedChecksum = reader.readLine();
-
-        if (expectedChecksum != null) {
-          expectedChecksum = expectedChecksum.split("\\s")[0].trim();
-        }
+        return reader.readLine();
       }
     } catch (URISyntaxException use) {
       throw new IOException("Expected SHA512 checksum could not be retrieved for " +
-          downloadedModel.getFileName(), use);
+          model.getFileName(), use);
     }
+  }
 
-    // Validate SHA512 checksum
-    final String actualChecksum = calculateSHA512(downloadedModel);
+  /**
+   * Extracts the hash from the content of a checksum file, which holds the hash followed by the
+   * name of the file it applies to.
+   */
+  private static String parseChecksum(String checksumFileContent) {
+    if (checksumFileContent == null) {
+      return null;
+    }
+    final String trimmed = checksumFileContent.trim();
+    return trimmed.isEmpty() ? null : trimmed.split("\\s")[0];
+  }
+
+  private static void verifyChecksum(Path model, String expectedChecksum) throws IOException {
+    final String actualChecksum = calculateSHA512(model);
     if (!actualChecksum.equalsIgnoreCase(expectedChecksum)) {
-      throw new IOException("SHA512 checksum validation failed for " + downloadedModel.getFileName() +
+      throw new IOException("SHA512 checksum validation failed for " + model.getFileName() +
           ". Expected: " + expectedChecksum + ", but got: " + actualChecksum);
     }
+  }
+
+  /**
+   * Stores the published checksum file alongside the model. A failure to do so is not fatal:
+   * it only means the next load falls back to retrieving the published checksum again.
+   */
+  private static void storeChecksumFile(Path model, String checksumFileContent) {
+    final Path checksumFile = checksumPathFor(model);
+    try {
+      Files.writeString(checksumFile, checksumFileContent, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      logger.warn("Could not store the expected checksum at {}.", checksumFile, e);
+    }
+  }
+
+  private static Path checksumPathFor(Path model) {
+    return model.resolveSibling(model.getFileName() + CHECKSUM_EXTENSION);
   }
 
   private static String calculateSHA512(Path file) throws IOException {

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/util/DownloadUtilCacheIntegrityTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/util/DownloadUtilCacheIntegrityTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import opennlp.tools.chunker.ChunkerModel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that models served from the local download home are checked against their
+ * SHA-512 checksum, and that doing so does not require network access.
+ * <p>
+ * The "remote" side is a {@code file:} URL inside the test's temporary directory, so these
+ * tests never contact the CDN.
+ */
+public class DownloadUtilCacheIntegrityTest {
+
+  private static final String DOWNLOAD_HOME_PROPERTY = "OPENNLP_DOWNLOAD_HOME";
+
+  private static final String MODEL_FILENAME = "opennlp-test-chunker.bin";
+
+  /**
+   * The model that gets published, downloaded, and whose checksum is the authoritative one.
+   */
+  private static final String PUBLISHED_MODEL = "/opennlp/tools/chunker/chunker170default.bin";
+
+  /**
+   * A different, but equally loadable, model. Used to replace a cached file so that the only
+   * thing distinguishing it from the expected model is its checksum - not its parsability.
+   */
+  private static final String SUBSTITUTE_MODEL = "/opennlp/tools/chunker/chunker180custom.bin";
+
+  @TempDir
+  Path tempDir;
+
+  private Path downloadHome;
+  private Path remoteModel;
+  private Path remoteChecksum;
+  private URL modelUrl;
+  private String previousDownloadHome;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    previousDownloadHome = System.getProperty(DOWNLOAD_HOME_PROPERTY);
+    System.setProperty(DOWNLOAD_HOME_PROPERTY, tempDir.toString());
+    downloadHome = tempDir.resolve(".opennlp");
+
+    final Path remoteDir = Files.createDirectories(tempDir.resolve("remote"));
+    remoteModel = remoteDir.resolve(MODEL_FILENAME);
+    copyResource(PUBLISHED_MODEL, remoteModel);
+
+    remoteChecksum = remoteDir.resolve(MODEL_FILENAME + ".sha512");
+    Files.writeString(remoteChecksum, sha512(remoteModel) + "  " + MODEL_FILENAME,
+        StandardCharsets.UTF_8);
+
+    modelUrl = remoteModel.toUri().toURL();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (previousDownloadHome == null) {
+      System.clearProperty(DOWNLOAD_HOME_PROPERTY);
+    } else {
+      System.setProperty(DOWNLOAD_HOME_PROPERTY, previousDownloadHome);
+    }
+  }
+
+  /**
+   * Sanity check: a first download validates and populates the cache, storing the published
+   * checksum file next to the model so that later loads have something to check against.
+   */
+  @Test
+  void testFirstDownloadPopulatesCache() throws IOException {
+    assertNotNull(DownloadUtil.downloadModel(modelUrl, ChunkerModel.class));
+    assertTrue(Files.exists(downloadHome.resolve(MODEL_FILENAME)),
+        "The model should have been cached in the download home");
+
+    final Path sidecar = downloadHome.resolve(MODEL_FILENAME + ".sha512");
+    assertTrue(Files.exists(sidecar), "The published checksum should have been stored");
+    assertEquals(Files.readString(remoteChecksum, StandardCharsets.UTF_8).strip(),
+        Files.readString(sidecar, StandardCharsets.UTF_8).strip(),
+        "The stored checksum should be interchangeable with the published one");
+  }
+
+  /**
+   * The actual defect: once a model is cached, its contents are never re-checked. The cached
+   * file is replaced with a <em>different but perfectly loadable</em> model, so that a passing
+   * result cannot be explained by the model parser rejecting garbage.
+   */
+  @Test
+  void testTamperedCachedModelIsRejected() throws IOException {
+    assertNotNull(DownloadUtil.downloadModel(modelUrl, ChunkerModel.class));
+
+    copyResource(SUBSTITUTE_MODEL, downloadHome.resolve(MODEL_FILENAME));
+
+    final IOException e = assertThrows(IOException.class,
+        () -> DownloadUtil.downloadModel(modelUrl, ChunkerModel.class),
+        "A cached model that no longer matches its published checksum must be rejected");
+    assertTrue(e.getMessage().contains("SHA512"),
+        "Expected a checksum failure, but got: " + e.getMessage());
+  }
+
+  /**
+   * Guards the constraint called out in OPENNLP-1902: verifying the cache must not turn every
+   * cached load into a network request. Both published artifacts are removed after the first
+   * download, so any attempt to reach the "remote" side would fail.
+   */
+  @Test
+  void testValidCachedModelLoadsWithoutNetworkAccess() throws IOException {
+    assertNotNull(DownloadUtil.downloadModel(modelUrl, ChunkerModel.class));
+
+    Files.delete(remoteChecksum);
+    Files.delete(remoteModel);
+
+    assertNotNull(DownloadUtil.downloadModel(modelUrl, ChunkerModel.class),
+        "A valid cached model must still load when the CDN is unreachable");
+  }
+
+  /**
+   * A cache populated by an older OpenNLP release has no checksum sidecar. When the published
+   * checksum is still reachable it must be used, so that pre-existing caches are covered too.
+   */
+  @Test
+  void testLegacyCacheWithoutSidecarIsVerified() throws IOException {
+    Files.createDirectories(downloadHome);
+    copyResource(SUBSTITUTE_MODEL, downloadHome.resolve(MODEL_FILENAME));
+
+    final IOException e = assertThrows(IOException.class,
+        () -> DownloadUtil.downloadModel(modelUrl, ChunkerModel.class),
+        "A legacy cached model must be verified against the published checksum");
+    assertTrue(e.getMessage().contains("SHA512"),
+        "Expected a checksum failure, but got: " + e.getMessage());
+  }
+
+  /**
+   * The other half of the legacy-cache decision: when there is no sidecar and the published
+   * checksum cannot be reached either, the model is loaded rather than refused, so that an
+   * offline download home populated by an older release keeps working. Nothing is stored in
+   * that case, so the verification is retried the next time the CDN is available.
+   */
+  @Test
+  void testLegacyCacheIsLoadedWhenChecksumIsUnreachable() throws IOException {
+    Files.createDirectories(downloadHome);
+    copyResource(PUBLISHED_MODEL, downloadHome.resolve(MODEL_FILENAME));
+    Files.delete(remoteChecksum);
+
+    assertNotNull(DownloadUtil.downloadModel(modelUrl, ChunkerModel.class),
+        "A legacy cached model must still load when the published checksum is unreachable");
+    assertFalse(Files.exists(downloadHome.resolve(MODEL_FILENAME + ".sha512")),
+        "Nothing should be stored when the published checksum could not be retrieved");
+  }
+
+  private void copyResource(String resource, Path target) throws IOException {
+    try (InputStream in = DownloadUtilCacheIntegrityTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "Missing test resource: " + resource);
+      Files.createDirectories(target.getParent());
+      Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  private static String sha512(Path file) throws IOException {
+    try {
+      final MessageDigest digest = MessageDigest.getInstance("SHA-512");
+      return HexFormat.of().formatHex(digest.digest(Files.readAllBytes(file)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IOException("SHA-512 algorithm not found", e);
+    }
+  }
+}


### PR DESCRIPTION
Fixes [OPENNLP-1902](https://issues.apache.org/jira/browse/OPENNLP-1902).

`downloadModel(URL, Class)` verified the SHA-512 checksum only on the path where the model was actually fetched, so once a model was in the download home every subsequent load trusted it unconditionally.

### Approach

- The published `.sha512` is stored next to the model on first download, so the cache carries its own reference checksum.
- A cached model is re-verified against that stored checksum on every load. This is done locally, with no request to the CDN — calling `validateModel(...)` directly on the cache path would have closed the gap but turned every cached load into a network request, which the ticket notes would break offline reuse of the download home.
- `existsModel(...)` and `downloadModel(...)` now share the same verification routine, so the two entry points no longer disagree.
- Caches populated by earlier versions have no stored checksum. For those the published one is fetched once and then stored; if it cannot be retrieved, the model is loaded and a warning is logged so existing offline setups keep working. I am happy to make this fail closed instead if that is preferred.
- The sidecar keeps the published file's content unmodified, so a cache stays verifiable with standard tooling (`shasum -a 512 -c`).
- `SECURITY.md` has been updated under "Downloaded models".

### Tests

`DownloadUtilCacheIntegrityTest` was added, covering:

- a first download populates the cache and stores the published checksum
- a tampered cached model is rejected
- a valid cached model still loads when the published artifacts are unavailable
- a legacy cache without a sidecar is verified when the checksum is reachable
- a legacy cache without a sidecar loads when the checksum is unreachable, storing nothing

The tests never touch the network: the remote side is a `file:` URL in a temporary directory and the download home is redirected via `OPENNLP_DOWNLOAD_HOME`. The tampering test substitutes a different but valid model rather than random bytes, so a failure can only come from the checksum comparison and not from the model parser rejecting malformed input.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Does your PR title start with OPENNLP-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?
- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn clean install at the root opennlp folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? (No new dependencies.)
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file in opennlp folder? (Not applicable.)
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found in opennlp folder? (Not applicable.)

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

@rzo1 — Can you please review the changes. Thank you.