### PR TITLE
[2.x] OPENNLP-1905: Default-locale case folding breaks Morfologik dictionary lookup

### DIFF
--- a/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/lemmatizer/MorfologikLemmatizer.java
+++ b/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/lemmatizer/MorfologikLemmatizer.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
@@ -63,7 +64,7 @@ public class MorfologikLemmatizer implements Lemmatizer {
   }
 
   private List<String> lemmatize(String word, String postag) {
-    List<WordData> dictMap = new DictionaryLookup(dictionary).lookup(word.toLowerCase());
+    List<WordData> dictMap = new DictionaryLookup(dictionary).lookup(word.toLowerCase(Locale.ROOT));
     Set<String> lemmas = new HashSet<>();
     for (WordData wordData : dictMap) {
       if (Objects.equals(postag, asString(wordData.getTag()))) {

--- a/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/tagdict/MorfologikTagDictionary.java
+++ b/opennlp-morfologik-addon/src/main/java/opennlp/morfologik/tagdict/MorfologikTagDictionary.java
@@ -19,6 +19,7 @@ package opennlp.morfologik.tagdict;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import morfologik.stemming.Dictionary;
 import morfologik.stemming.DictionaryLookup;
@@ -64,7 +65,7 @@ public class MorfologikTagDictionary implements TagDictionary {
   @Override
   public String[] getTags(String word) {
     if (!isCaseSensitive) {
-      word = word.toLowerCase();
+      word = word.toLowerCase(Locale.ROOT);
     }
 
     List<WordData> data = dictLookup.lookup(word);

--- a/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/AbstractMorfologikTest.java
+++ b/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/AbstractMorfologikTest.java
@@ -31,14 +31,26 @@ import opennlp.morfologik.builder.MorfologikDictionaryBuilder;
 public abstract class AbstractMorfologikTest {
 
   protected static Path createMorfologikDictionary() throws Exception {
+    return createMorfologikDictionary("dictionaryWithLemma");
+  }
+
+  /**
+   * Builds a Morfologik FSA dictionary from the {@code .txt} and {@code .info} test
+   * resources sharing the given base name.
+   *
+   * @param resourceBaseName The base name of the tab separated dictionary resource pair.
+   *
+   * @return The {@link Path} of the built FSA dictionary.
+   */
+  protected static Path createMorfologikDictionary(String resourceBaseName) throws Exception {
     Path tabFilePath = File.createTempFile(AbstractMorfologikTest.class.getName(), ".txt").toPath();
     tabFilePath.toFile().deleteOnExit();
     Path infoFilePath = DictionaryMetadata.getExpectedMetadataLocation(tabFilePath);
     infoFilePath.toFile().deleteOnExit();
 
-    Files.copy(getResourceStream("/dictionaryWithLemma.txt"), tabFilePath,
+    Files.copy(getResourceStream("/" + resourceBaseName + ".txt"), tabFilePath,
             StandardCopyOption.REPLACE_EXISTING);
-    Files.copy(getResourceStream("/dictionaryWithLemma.info"), infoFilePath,
+    Files.copy(getResourceStream("/" + resourceBaseName + ".info"), infoFilePath,
             StandardCopyOption.REPLACE_EXISTING);
 
     MorfologikDictionaryBuilder builder = new MorfologikDictionaryBuilder();

--- a/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/MorfologikLocaleTest.java
+++ b/opennlp-morfologik-addon/src/test/java/opennlp/morfologik/MorfologikLocaleTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.morfologik;
+
+import java.nio.file.Path;
+import java.util.Locale;
+
+import morfologik.stemming.Dictionary;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import opennlp.morfologik.lemmatizer.MorfologikLemmatizer;
+import opennlp.morfologik.tagdict.MorfologikTagDictionary;
+
+/**
+ * Tests that the case insensitive lookups into a prebuilt Morfologik FSA dictionary do not
+ * depend on the JVM's default {@link Locale}.
+ * <p>
+ * The FSA is built once and shipped; folding the query with the default locale makes the
+ * same dictionary answer differently on different JVMs.
+ */
+public class MorfologikLocaleTest extends AbstractMorfologikTest {
+
+  /**
+   * Turkish folds {@code 'I'} to the dotless {@code 'ı'} (U+0131) instead of {@code 'i'}.
+   */
+  private static final Locale TURKISH = new Locale("tr", "TR");
+
+  private final Locale defaultLocale = Locale.getDefault();
+
+  @AfterEach
+  void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
+  }
+
+  @Test
+  public void testLemmatizeIsIndependentOfDefaultLocale() throws Exception {
+    final MorfologikLemmatizer lemmatizer = new MorfologikLemmatizer(createLocaleDictionary());
+
+    Locale.setDefault(TURKISH);
+
+    final String[] lemmas = lemmatizer.lemmatize(
+        new String[] {"Illinois", "INDICES"}, new String[] {"PROP", "NOUN"});
+
+    Assertions.assertArrayEquals(new String[] {"Illinois", "index"}, lemmas);
+  }
+
+  @Test
+  public void testGetTagsIsIndependentOfDefaultLocale() throws Exception {
+    final MorfologikTagDictionary tagDictionary =
+        new MorfologikTagDictionary(Dictionary.read(createLocaleDictionary()), false);
+
+    Locale.setDefault(TURKISH);
+
+    Assertions.assertArrayEquals(new String[] {"PROP"}, tagDictionary.getTags("Illinois"));
+    Assertions.assertArrayEquals(new String[] {"NOUN"}, tagDictionary.getTags("INDICES"));
+  }
+
+  private static Path createLocaleDictionary() throws Exception {
+    final Path output = createMorfologikDictionary("dictionaryLocaleSafety");
+    output.toFile().deleteOnExit();
+    return output;
+  }
+}

--- a/opennlp-morfologik-addon/src/test/resources/dictionaryLocaleSafety.info
+++ b/opennlp-morfologik-addon/src/test/resources/dictionaryLocaleSafety.info
@@ -1,0 +1,15 @@
+#
+# REQUIRED PROPERTIES
+#
+
+# Column (lemma, inflected, tag) separator. This must be a single byte in the target encoding.
+fsa.dict.separator=,
+
+# The charset in which the input is encoded. UTF-8 is strongly recommended.
+fsa.dict.encoding=UTF-8
+
+# The type of lemma-inflected form encoding compression that precedes automaton
+# construction. Allowed values: [suffix, infix, prefix, none].
+# Details are in Daciuk's paper and in the code. 
+# Leave at 'prefix' if not sure.
+fsa.dict.encoder=prefix

--- a/opennlp-morfologik-addon/src/test/resources/dictionaryLocaleSafety.txt
+++ b/opennlp-morfologik-addon/src/test/resources/dictionaryLocaleSafety.txt
@@ -1,0 +1,2 @@
+Illinois,illinois,PROP
+index,indices,NOUN


### PR DESCRIPTION
Backport of #1207 (OPENNLP-1905) to opennlp-2.x.

Both Morfologik lookups fold the query word with the JVM default locale before searching a prebuilt FSA dictionary. Under `tr` or `az` the dotless i means a capitalised word containing `I` folds to something the dictionary does not contain, so the lookup misses and returns null. Nothing throws.

`MorfologikTagDictionary` is the more consequential of the two, because it feeds POS tagging constraints. Its failure does not merely lose a lemma, it changes tagger output depending on the JVM locale the tagger runs under.

The dictionary is an external prebuilt artifact with fixed content, so a user cannot work around this by editing their own data.

### Reproduction

Assertion failures against unfixed code with `Locale.setDefault` of `tr`:

```
MorfologikLemmatizer.lemmatize   expected <Illinois>   but was <null>
MorfologikTagDictionary.getTags  actual array was <null>
```

`"Illinois".toLowerCase()` under `tr` yields `ıllinois`, which is absent from an ASCII-lowercase FSA.

### Sites

| Location | Expression |
|---|---|
| `MorfologikLemmatizer.java` | `lookup(word.toLowerCase())` |
| `MorfologikTagDictionary.java` | `word = word.toLowerCase()` (case-insensitive mode) |

### Why `Locale.ROOT`

Same reasoning as OPENNLP-1904. `StringUtil.toLowerCase` maps code points through `Character.toLowerCase`, which is context free and disagrees with `String.toLowerCase(Locale.ROOT)` on context-sensitive mappings such as Greek final sigma and on one-to-many mappings such as `ß`. Existing FSA dictionaries were built against the English-locale fold, which is byte-identical to `Locale.ROOT`, so this keeps them working unchanged. **No dictionary regeneration is required.**

### Tests

`MorfologikLocaleTest` adds two tests, both verified to fail before the fix and pass after. New fixture `dictionaryLocaleSafety.{txt,info}`, plus a `createMorfologikDictionary(String)` overload on `AbstractMorfologikTest` (the existing no-arg method delegates to it) so the shared `dictionaryWithLemma` fixture is not perturbed.

### Backport notes

- 2.x targets Java 17, so the test builds the Turkish locale with `new Locale("tr", "TR")` rather than `Locale.of`.
- Module is `opennlp-morfologik-addon` on this branch. Its suite plus `opennlp-tools`: 1,359 tests, 0 failures.
