### PR TITLE
[2.x] OPENNLP-1903: Replace per-candidate Sequence copies with chain nodes in BeamSearch

### DIFF
--- a/opennlp-tools/src/jmh/java/opennlp/tools/ml/BeamSearchBenchmark.java
+++ b/opennlp-tools/src/jmh/java/opennlp/tools/ml/BeamSearchBenchmark.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.ml;
+
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import opennlp.tools.util.BeamSearchContextGenerator;
+import opennlp.tools.util.SequenceValidator;
+
+/**
+ * JMH benchmark for {@link BeamSearch} on long input sequences.
+ * <p>
+ * One op = one {@code bestSequence} call on a synthetic token sequence of
+ * {@code sequenceLength} tokens. Long sequences are what expose the quadratic
+ * per-candidate outcome-list copying removed with OPENNLP-1903; sentences of
+ * 5-10 tokens, as used by the ME benchmarks, show no measurable difference.
+ * Only public API that predates OPENNLP-1903 is used
+ * ({@code BeamSearch(int, MaxentModel, int)} and
+ * {@code bestSequence(T[], Object[], BeamSearchContextGenerator, SequenceValidator)}),
+ * so the same compiled class exercises both implementations: to produce a
+ * baseline, place an {@code opennlp-ml-commons} jar built before OPENNLP-1903
+ * on the classpath ahead of the freshly built classes and rerun.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 10, time = 2)
+@Fork(2)
+public class BeamSearchBenchmark {
+
+  private static final int BEAM_SIZE = 3;
+  private static final int NUM_INPUTS = 64;
+  private static final int VOCAB_SIZE = 17;
+  /** Seed for both the input generator and the {@link SeededMaxentModel}. */
+  private static final long SEED = 0x5eedL;
+  private static final String[] MODEL_OUTCOMES = {"start", "cont", "other"};
+
+  private static final SequenceValidator<String> ACCEPT_ALL =
+      (i, input, outcomes, outcome) -> true;
+
+  @State(Scope.Benchmark)
+  public static class SearchState {
+
+    @Param({"8", "64", "256"})
+    int sequenceLength;
+
+    @Param({"0", "64"})
+    int cacheSize;
+
+    BeamSearch beamSearch;
+    TokenContextGenerator contextGenerator;
+    String[][] inputs;
+    final AtomicInteger cursor = new AtomicInteger();
+
+    @Setup(Level.Trial)
+    public void create() {
+      beamSearch = new BeamSearch(BEAM_SIZE,
+          new SeededMaxentModel(MODEL_OUTCOMES, SEED), cacheSize);
+      contextGenerator = new TokenContextGenerator();
+      inputs = new String[NUM_INPUTS][];
+      Random rnd = new Random(SEED);
+      for (int n = 0; n < NUM_INPUTS; n++) {
+        String[] input = new String[sequenceLength];
+        for (int i = 0; i < sequenceLength; i++) {
+          input[i] = "t" + rnd.nextInt(VOCAB_SIZE);
+        }
+        inputs[n] = input;
+      }
+    }
+
+    String[] nextInput() {
+      // Rotate through the input pool so repeated invocations decode different
+      // sequences instead of hammering one fully cache-warm input.
+      return inputs[Math.floorMod(cursor.getAndIncrement(), NUM_INPUTS)];
+    }
+  }
+
+  /**
+   * Derives contexts from the current token and the previous outcome, interned
+   * so identical context content maps to the same {@code String[]} instance
+   * and the identity-keyed contexts cache in {@link BeamSearch} produces hits.
+   * Thread-safe.
+   */
+  static final class TokenContextGenerator implements BeamSearchContextGenerator<String> {
+
+    private final ConcurrentHashMap<String, String[]> intern = new ConcurrentHashMap<>();
+
+    @Override
+    public String[] getContext(int index, String[] sequence,
+                               String[] priorDecisions, Object[] additionalContext) {
+      String prev = index > 0 ? priorDecisions[index - 1] : "<s>";
+      String[] ctx = {"tok=" + sequence[index], "prev=" + prev};
+      String key = ctx[0] + '|' + ctx[1];
+      String[] existing = intern.putIfAbsent(key, ctx);
+      return existing != null ? existing : ctx;
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void bestSequenceSingle(SearchState state, Blackhole bh) {
+    bh.consume(state.beamSearch.bestSequence(state.nextInput(), null,
+        state.contextGenerator, ACCEPT_ALL));
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void bestSequenceConcurrent(SearchState state, Blackhole bh) {
+    bh.consume(state.beamSearch.bestSequence(state.nextInput(), null,
+        state.contextGenerator, ACCEPT_ALL));
+  }
+
+  /**
+   * Quick local iteration only: {@code forks(0)} disables JVM fork isolation
+   * (unlike {@code mvn} with the {@code jmh} profile).
+   * Use the Maven-invoked configuration for publishable numbers.
+   */
+  public static void main(String[] args) throws Exception {
+    Options opt = new OptionsBuilder()
+        .include(BeamSearchBenchmark.class.getSimpleName())
+        .forks(0)
+        .warmupIterations(1)
+        .warmupTime(TimeValue.seconds(1))
+        .measurementIterations(1)
+        .measurementTime(TimeValue.seconds(1))
+        .build();
+    new Runner(opt).run();
+  }
+}

--- a/opennlp-tools/src/main/java/opennlp/tools/ml/BeamSearch.java
+++ b/opennlp-tools/src/main/java/opennlp/tools/ml/BeamSearch.java
@@ -18,7 +18,6 @@
 package opennlp.tools.ml;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
 
@@ -51,6 +50,72 @@ public class BeamSearch implements SequenceClassificationModel {
   private final double[] probs;
   private Cache<String[], double[]> contextsCache;
   private static final int zeroLog = -100000;
+
+  /**
+   * Immutable node in a backward-linked chain of outcome candidates, used only inside
+   * {@link #bestSequences(int, Object[], Object[], double, BeamSearchContextGenerator, SequenceValidator)}.
+   * A node stores its own outcome plus a parent link, so extending a candidate is O(1);
+   * the full outcome array is materialized only when a candidate is expanded.
+   * Score accumulation ({@code parent.score + StrictMath.log(prob)}) mirrors
+   * {@link Sequence#Sequence(Sequence, String, double)}, and descending score order
+   * mirrors {@link Sequence#compareTo(Sequence)}, so search results stay bit-identical
+   * to a search over {@link Sequence} instances.
+   */
+  private static final class SearchNode implements Comparable<SearchNode> {
+    private final SearchNode parent;
+    private final String outcome; // null on the root
+    private final double prob;
+    private final double score;
+    private final int size;
+
+    /**
+     * Creates the root node: the empty candidate with score {@code 0}.
+     */
+    private SearchNode() {
+      this.parent = null;
+      this.outcome = null;
+      this.prob = 0d;
+      this.score = 0d;
+      this.size = 0;
+    }
+
+    /**
+     * Creates a candidate extending {@code parent} by one outcome.
+     *
+     * @param parent The candidate to extend. Must not be {@code null}.
+     * @param outcome The outcome to append.
+     * @param prob The probability of {@code outcome}.
+     */
+    private SearchNode(SearchNode parent, String outcome, double prob) {
+      this.parent = parent;
+      this.outcome = outcome;
+      this.prob = prob;
+      this.score = parent.score + StrictMath.log(prob);
+      this.size = parent.size + 1;
+    }
+
+    /**
+     * @return The outcomes on the path from the root to this node, in sequence order.
+     */
+    private String[] outcomes() {
+      final String[] outcomes = new String[size];
+      SearchNode node = this;
+      for (int i = size - 1; i >= 0; i--) {
+        outcomes[i] = node.outcome;
+        node = node.parent;
+      }
+      return outcomes;
+    }
+
+    /**
+     * Orders nodes by descending score, as {@link Sequence#compareTo(Sequence)} does;
+     * nodes with equal scores keep the order of the queue that holds them.
+     */
+    @Override
+    public int compareTo(SearchNode other) {
+      return Double.compare(other.score, this.score);
+    }
+  }
 
   /**
    * Initializes a {@link BeamSearch} instance.
@@ -101,10 +166,10 @@ public class BeamSearch implements SequenceClassificationModel {
       Object[] additionalContext, double minSequenceScore,
       BeamSearchContextGenerator<T> cg, SequenceValidator<T> validator) {
 
-    Queue<Sequence> prev = new PriorityQueue<>(size);
-    Queue<Sequence> next = new PriorityQueue<>(size);
-    Queue<Sequence> tmp;
-    prev.add(new Sequence());
+    Queue<SearchNode> prev = new PriorityQueue<>(size);
+    Queue<SearchNode> next = new PriorityQueue<>(size);
+    Queue<SearchNode> tmp;
+    prev.add(new SearchNode());
 
     if (additionalContext == null) {
       additionalContext = EMPTY_ADDITIONAL_CONTEXT;
@@ -114,13 +179,18 @@ public class BeamSearch implements SequenceClassificationModel {
       int sz = StrictMath.min(size, prev.size());
 
       for (int sc = 0; prev.size() > 0 && sc < sz; sc++) {
-        Sequence top = prev.remove();
-        List<String> tmpOutcomes = top.getOutcomes();
-        String[] outcomes = tmpOutcomes.toArray(new String[0]);
-        String[] contexts = cg.getContext(i, sequence, outcomes, additionalContext);
-        double[] scores;
+        final SearchNode top = prev.remove();
+        final String[] outcomes = top.outcomes();
+        final String[] contexts = cg.getContext(i, sequence, outcomes, additionalContext);
+        final double[] scores;
         if (contextsCache != null) {
-          scores = contextsCache.computeIfAbsent(contexts, c -> model.eval(c, probs));
+          scores = contextsCache.computeIfAbsent(contexts, c -> {
+            // eval() writes into probs; cache values must be immutable copies for reuse.
+            double[] res = model.eval(c, probs);
+            double[] copy = new double[res.length];
+            System.arraycopy(res, 0, copy, 0, res.length);
+            return copy;
+          });
         } else {
           scores = model.eval(contexts, probs);
         }
@@ -136,8 +206,8 @@ public class BeamSearch implements SequenceClassificationModel {
           if (scores[p] >= min) {
             String out = model.getOutcome(p);
             if (validator.validSequence(i, sequence, outcomes, out)) {
-              Sequence ns = new Sequence(top, out, scores[p]);
-              if (ns.getScore() > minSequenceScore) {
+              final SearchNode ns = new SearchNode(top, out, scores[p]);
+              if (ns.score > minSequenceScore) {
                 next.add(ns);
               }
             }
@@ -148,8 +218,8 @@ public class BeamSearch implements SequenceClassificationModel {
           for (int p = 0; p < scores.length; p++) {
             String out = model.getOutcome(p);
             if (validator.validSequence(i, sequence, outcomes, out)) {
-              Sequence ns = new Sequence(top, out, scores[p]);
-              if (ns.getScore() > minSequenceScore) {
+              final SearchNode ns = new SearchNode(top, out, scores[p]);
+              if (ns.score > minSequenceScore) {
                 next.add(ns);
               }
             }
@@ -168,7 +238,22 @@ public class BeamSearch implements SequenceClassificationModel {
     Sequence[] topSequences = new Sequence[numSeq];
 
     for (int seqIndex = 0; seqIndex < numSeq; seqIndex++) {
-      topSequences[seqIndex] = prev.remove();
+      final SearchNode winner = prev.remove();
+      final String[] outs = new String[winner.size];
+      final double[] winnerProbs = new double[winner.size];
+      SearchNode node = winner;
+      for (int j = winner.size - 1; j >= 0; j--) {
+        outs[j] = node.outcome;
+        winnerProbs[j] = node.prob;
+        node = node.parent;
+      }
+      // Sequence.add accumulates score += StrictMath.log(p) per element, so rebuilding in
+      // chain order yields a score bit-identical to the node's accumulated score.
+      final Sequence seq = new Sequence();
+      for (int j = 0; j < outs.length; j++) {
+        seq.add(outs[j], winnerProbs[j]);
+      }
+      topSequences[seqIndex] = seq;
     }
 
     return topSequences;

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/BeamSearchEquivalenceTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/BeamSearchEquivalenceTest.java
@@ -1,0 +1,609 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.ml;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import opennlp.tools.ml.model.MaxentModel;
+import opennlp.tools.util.BeamSearchContextGenerator;
+import opennlp.tools.util.Cache;
+import opennlp.tools.util.Sequence;
+import opennlp.tools.util.SequenceValidator;
+
+/**
+ * Equivalence tests for the {@code BeamSearch.bestSequences} chain-node implementation
+ * introduced with OPENNLP-1903.
+ * <p>
+ * Every test runs the current {@link BeamSearch} side by side with
+ * {@link #referenceBestSequences}, a faithful port of the per-candidate
+ * {@link Sequence}-copying implementation that OPENNLP-1903 replaced, and demands
+ * identical output: same number of sequences, identical outcome lists
+ * (order-sensitive), and bit-identical scores and per-position probabilities.
+ */
+public class BeamSearchEquivalenceTest {
+
+  /** Mirror of the private {@code BeamSearch.ZERO_LOG} default threshold. */
+  private static final double ZERO_LOG = -100000;
+
+  private static final String[] OUTCOMES = {"o0", "o1", "o2", "o3"};
+  private static final long MODEL_SEED = 0x5eedL;
+
+  private static final int[] BEAM_SIZES = {1, 2, 3, 5, 10}; // 10 > OUTCOMES.length on purpose
+  private static final int[] INPUT_LENGTHS = {0, 1, 2, 7, 33, 128};
+  private static final int[] CACHE_SIZES = {0, 64};
+
+  private static final SequenceValidator<String> ACCEPT_ALL =
+      (i, input, outcomes, outcome) -> true;
+
+  /** A {@link SequenceValidator} paired with a stable name for test display. */
+  record NamedValidator(String name, SequenceValidator<String> validator) {
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+  private static final List<NamedValidator> VALIDATORS = List.of(
+      new NamedValidator("rejectOneOutcome",
+          (i, input, outcomes, outcome) -> !"o2".equals(outcome)),
+      // Rejects every outcome at position 2: at that position the threshold loop adds
+      // nothing, so the next.isEmpty() fallback runs (and also rejects everything,
+      // killing the search for inputs longer than 2).
+      new NamedValidator("rejectAllAtPosition2",
+          (i, input, outcomes, outcome) -> i != 2),
+      // Rejects everything except "o3" at position 2: the fallback actually populates
+      // next with the sub-threshold "o3" candidate whenever "o3" fell below the min.
+      new NamedValidator("onlyO3AtPosition2",
+          (i, input, outcomes, outcome) -> i != 2 || "o3".equals(outcome)),
+      new NamedValidator("rejectEverything",
+          (i, input, outcomes, outcome) -> false));
+
+  // ---------------------------------------------------------------------------
+  // Context generator
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds contexts from the index, the token, the previous outcome and the first
+   * additional-context element. Identical context content is interned to the same
+   * {@code String[]} instance so the identity-keyed contexts {@link Cache} in
+   * {@link BeamSearch} actually produces hits. Thread-safe.
+   */
+  static final class SeededContextGenerator implements BeamSearchContextGenerator<String> {
+
+    private final ConcurrentHashMap<String, String[]> intern = new ConcurrentHashMap<>();
+    private final AtomicInteger callCount = new AtomicInteger();
+
+    @Override
+    public String[] getContext(int index, String[] sequence,
+                               String[] priorDecisions, Object[] additionalContext) {
+      callCount.incrementAndGet();
+      String prev = index > 0 ? priorDecisions[index - 1] : "<s>";
+      String ac = additionalContext != null && additionalContext.length > 0
+          ? String.valueOf(additionalContext[0]) : "-";
+      String[] ctx = {"ix=" + index, "tok=" + sequence[index], "prev=" + prev, "ac=" + ac};
+      String key = String.join("", ctx);
+      String[] existing = intern.putIfAbsent(key, ctx);
+      return existing != null ? existing : ctx;
+    }
+
+    /**
+     * @return The number of {@link #getContext} invocations so far.
+     */
+    int callCount() {
+      return callCount.get();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reference implementation: faithful port of the bestSequences implementation
+  // prior to OPENNLP-1903
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Port of the {@code BeamSearch.bestSequences} control flow prior to OPENNLP-1903:
+   * PriorityQueue over {@link Sequence}, per-candidate
+   * {@code new Sequence(top, out, scores[p])} copies, tempScores sort/min, the
+   * {@code next.isEmpty()} advance-all-valid fallback, the queue swap, and the winner
+   * removal order. The cache path (a {@code Cache<String[], double[]>} exactly like the
+   * per-thread one in {@link BeamSearch}) is used when {@code cacheSize > 0}; otherwise
+   * the uncached eval path is taken.
+   */
+  static <T> Sequence[] referenceBestSequences(
+      final int numSequences, final T[] sequence, final Object[] additionalContext,
+      final double minSequenceScore, final BeamSearchContextGenerator<T> cg,
+      final SequenceValidator<T> validator, final MaxentModel model,
+      final int beamSize, final int cacheSize) {
+
+    // Local equivalents of the per-thread CacheState in BeamSearch.
+    final double[] probs = new double[model.getNumOutcomes()];
+    final double[] tempScores = new double[model.getNumOutcomes()];
+    final Cache<String[], double[]> cache = cacheSize > 0 ? new Cache<>(cacheSize) : null;
+
+    Queue<Sequence> prev = new PriorityQueue<>(beamSize);
+    Queue<Sequence> next = new PriorityQueue<>(beamSize);
+    Queue<Sequence> tmp;
+    prev.add(new Sequence());
+
+    Object[] context = additionalContext;
+    if (context == null) {
+      context = new Object[0];
+    }
+
+    for (int i = 0; i < sequence.length; i++) {
+      final int sz = StrictMath.min(beamSize, prev.size());
+
+      for (int sc = 0; prev.size() > 0 && sc < sz; sc++) {
+        final Sequence top = prev.remove();
+        final List<String> tmpOutcomes = top.getOutcomes();
+        final String[] outcomes = tmpOutcomes.toArray(new String[0]);
+        final String[] contexts = cg.getContext(i, sequence, outcomes, context);
+        final double[] scores;
+        if (cache != null) {
+          scores = cache.computeIfAbsent(contexts, c -> {
+            double[] res = model.eval(c, probs);
+            double[] copy = new double[res.length];
+            System.arraycopy(res, 0, copy, 0, res.length);
+            return copy;
+          });
+        } else {
+          scores = model.eval(contexts, probs);
+        }
+
+        System.arraycopy(scores, 0, tempScores, 0, scores.length);
+        Arrays.sort(tempScores);
+
+        final double min = tempScores[StrictMath.max(0, scores.length - beamSize)];
+
+        for (int p = 0; p < scores.length; p++) {
+          if (scores[p] >= min) {
+            final String out = model.getOutcome(p);
+            if (validator.validSequence(i, sequence, outcomes, out)) {
+              final Sequence ns = new Sequence(top, out, scores[p]);
+              if (ns.getScore() > minSequenceScore) {
+                next.add(ns);
+              }
+            }
+          }
+        }
+
+        if (next.isEmpty()) { // if no advanced sequences, advance all valid
+          for (int p = 0; p < scores.length; p++) {
+            final String out = model.getOutcome(p);
+            if (validator.validSequence(i, sequence, outcomes, out)) {
+              final Sequence ns = new Sequence(top, out, scores[p]);
+              if (ns.getScore() > minSequenceScore) {
+                next.add(ns);
+              }
+            }
+          }
+        }
+      }
+
+      // make prev = next; and re-init next (reuse existing prev set once cleared)
+      prev.clear();
+      tmp = prev;
+      prev = next;
+      next = tmp;
+    }
+
+    final int numSeq = StrictMath.min(numSequences, prev.size());
+    final Sequence[] topSequences = new Sequence[numSeq];
+
+    for (int seqIndex = 0; seqIndex < numSeq; seqIndex++) {
+      topSequences[seqIndex] = prev.remove();
+    }
+
+    return topSequences;
+  }
+
+  /** Reference twin of the two-arg overload (default {@code ZERO_LOG} threshold). */
+  static <T> Sequence[] referenceBestSequences(
+      int numSequences, T[] sequence, Object[] additionalContext,
+      BeamSearchContextGenerator<T> cg, SequenceValidator<T> validator,
+      MaxentModel model, int beamSize, int cacheSize) {
+    return referenceBestSequences(numSequences, sequence, additionalContext, ZERO_LOG,
+        cg, validator, model, beamSize, cacheSize);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @return A new model over {@link #OUTCOMES} seeded with {@link #MODEL_SEED}.
+   */
+  private static MaxentModel model() {
+    return new SeededMaxentModel(OUTCOMES, MODEL_SEED);
+  }
+
+  /**
+   * @return A seeded pseudo-random token sequence of {@code length} tokens.
+   */
+  private static String[] randomInput(int length, long seed) {
+    Random rnd = new Random(seed);
+    String[] input = new String[length];
+    for (int i = 0; i < length; i++) {
+      input[i] = "t" + rnd.nextInt(17);
+    }
+    return input;
+  }
+
+  private static void assertBitIdentical(double expected, double actual, String what) {
+    Assertions.assertEquals(Double.doubleToRawLongBits(expected),
+        Double.doubleToRawLongBits(actual),
+        what + " (expected=" + expected + ", actual=" + actual + ")");
+  }
+
+  private static void assertSequencesEqual(Sequence[] expected, Sequence[] actual,
+                                           String caseDesc) {
+    Assertions.assertNotNull(actual, caseDesc + ": result array must not be null");
+    Assertions.assertEquals(expected.length, actual.length,
+        caseDesc + ": number of returned sequences");
+    for (int s = 0; s < expected.length; s++) {
+      String seqDesc = caseDesc + ", sequence[" + s + "]";
+      Assertions.assertEquals(expected[s].getOutcomes(), actual[s].getOutcomes(),
+          seqDesc + ": outcomes");
+      assertBitIdentical(expected[s].getScore(), actual[s].getScore(),
+          seqDesc + ": score");
+      Assertions.assertEquals(expected[s].getSize(), actual[s].getSize(),
+          seqDesc + ": size");
+      double[] expectedProbs = expected[s].getProbs();
+      double[] actualProbs = actual[s].getProbs();
+      Assertions.assertEquals(expectedProbs.length, actualProbs.length,
+          seqDesc + ": probs length");
+      for (int p = 0; p < expectedProbs.length; p++) {
+        assertBitIdentical(expectedProbs[p], actualProbs[p],
+            seqDesc + ": prob[" + p + "]");
+        assertBitIdentical(expected[s].getProb(p), actual[s].getProb(p),
+            seqDesc + ": getProb(" + p + ")");
+      }
+    }
+  }
+
+  private static String caseDesc(String test, int beam, int length, int cache) {
+    return test + "[beam=" + beam + ", len=" + length + ", cache=" + cache + "]";
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parameter sources
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @return The cartesian product of {@link #BEAM_SIZES}, {@link #INPUT_LENGTHS}
+   *         and {@link #CACHE_SIZES}.
+   */
+  static Stream<Arguments> beamLengthCacheMatrix() {
+    Stream.Builder<Arguments> cases = Stream.builder();
+    for (int beam : BEAM_SIZES) {
+      for (int length : INPUT_LENGTHS) {
+        for (int cache : CACHE_SIZES) {
+          cases.add(Arguments.of(beam, length, cache));
+        }
+      }
+    }
+    return cases.build();
+  }
+
+  /**
+   * @return The cartesian product of {@link #VALIDATORS}, {@link #BEAM_SIZES},
+   *         {@link #INPUT_LENGTHS} and {@link #CACHE_SIZES}.
+   */
+  static Stream<Arguments> validatorBeamLengthCacheMatrix() {
+    Stream.Builder<Arguments> cases = Stream.builder();
+    for (NamedValidator nv : VALIDATORS) {
+      for (int beam : BEAM_SIZES) {
+        for (int length : INPUT_LENGTHS) {
+          for (int cache : CACHE_SIZES) {
+            cases.add(Arguments.of(nv, beam, length, cache));
+          }
+        }
+      }
+    }
+    return cases.build();
+  }
+
+  /**
+   * @return The cartesian product of {@link #INPUT_LENGTHS} and {@link #CACHE_SIZES}.
+   */
+  static Stream<Arguments> lengthCacheMatrix() {
+    Stream.Builder<Arguments> cases = Stream.builder();
+    for (int length : INPUT_LENGTHS) {
+      for (int cache : CACHE_SIZES) {
+        cases.add(Arguments.of(length, cache));
+      }
+    }
+    return cases.build();
+  }
+
+  /**
+   * @return All values of {@link #CACHE_SIZES}.
+   */
+  static IntStream cacheSizes() {
+    return IntStream.of(CACHE_SIZES);
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. Equivalence matrix: beam sizes x input lengths x cache sizes,
+  //    default (ZERO_LOG) threshold via the two-arg overload, accept-all validator
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "beam={0}, len={1}, cache={2}")
+  @MethodSource("beamLengthCacheMatrix")
+  void equivalenceAcrossBeamSizesLengthsAndCaches(int beam, int length, int cache) {
+    MaxentModel model = model();
+    String[] input = randomInput(length, 1000L + length);
+    String desc = caseDesc("matrix", beam, length, cache);
+    SeededContextGenerator cg = new SeededContextGenerator();
+
+    Sequence[] expected = referenceBestSequences(1, input, null, cg, ACCEPT_ALL,
+        model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(1, input, null, cg, ACCEPT_ALL);
+
+    assertSequencesEqual(expected, actual, desc);
+    if (length == 0) {
+      Assertions.assertEquals(0, cg.callCount(),
+          desc + ": context generator must not be called for empty input");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 2. Equivalence with a tight minSequenceScore that actually filters candidates
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "beam={0}, len={1}, cache={2}")
+  @MethodSource("beamLengthCacheMatrix")
+  void equivalenceWithTightMinSequenceScore(int beam, int length, int cache) {
+    MaxentModel model = model();
+    String[] input = randomInput(length, 2000L + length);
+    String desc = caseDesc("threshold", beam, length, cache);
+
+    // Derive a threshold that bites: run uncapped, then cut between the best
+    // and worst candidate scores (or just above the best when only one exists).
+    Sequence[] uncapped = referenceBestSequences(beam, input, null,
+        new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
+    final double threshold;
+    if (uncapped.length == 0) {
+      threshold = 0;
+    } else {
+      double best = uncapped[0].getScore();
+      double worst = uncapped[uncapped.length - 1].getScore();
+      threshold = (uncapped.length > 1 && worst < best)
+          ? (best + worst) / 2.0 : best + 0.5;
+    }
+
+    Sequence[] expected = referenceBestSequences(1, input, null, threshold,
+        new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(1, input, null, threshold, new SeededContextGenerator(),
+            ACCEPT_ALL);
+
+    assertSequencesEqual(expected, actual, desc + ", threshold=" + threshold);
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3. Equivalence under restrictive validators, including the next.isEmpty()
+  //    advance-all-valid fallback and the reject-everything empty-result path
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "{0}, beam={1}, len={2}, cache={3}")
+  @MethodSource("validatorBeamLengthCacheMatrix")
+  void equivalenceWithRestrictiveValidators(NamedValidator nv, int beam, int length,
+                                            int cache) {
+    MaxentModel model = model();
+    String[] input = randomInput(length, 3000L + length);
+    String desc = caseDesc("validator-" + nv.name(), beam, length, cache);
+
+    Sequence[] expected = referenceBestSequences(1, input, null,
+        new SeededContextGenerator(), nv.validator(), model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(1, input, null, new SeededContextGenerator(),
+            nv.validator());
+
+    assertSequencesEqual(expected, actual, desc);
+    if ("rejectEverything".equals(nv.name()) && length > 0) {
+      Assertions.assertEquals(0, actual.length,
+          desc + ": reject-everything must yield an empty (non-null) array");
+      Assertions.assertEquals(0, expected.length,
+          desc + ": reference reject-everything must also be empty");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 4. numSequences > 1: winner order and scores match the reference exactly
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A model that returns the same distribution for every context, so candidates tie on
+   * score exactly and the result depends on queue order alone.
+   */
+  static final class ConstantModel implements MaxentModel {
+
+    private final double[] distribution;
+
+    ConstantModel(double... distribution) {
+      this.distribution = distribution;
+    }
+
+    @Override
+    public double[] eval(String[] context) {
+      return distribution.clone();
+    }
+
+    @Override
+    public double[] eval(String[] context, double[] probs) {
+      System.arraycopy(distribution, 0, probs, 0, distribution.length);
+      return probs;
+    }
+
+    @Override
+    public double[] eval(String[] context, float[] values) {
+      return eval(context);
+    }
+
+    @Override
+    public String getBestOutcome(double[] outcomes) {
+      return null;
+    }
+
+    @Override
+    public String getAllOutcomes(double[] outcomes) {
+      return null;
+    }
+
+    @Override
+    public String getOutcome(int i) {
+      return OUTCOMES[i];
+    }
+
+    @Override
+    public int getIndex(String outcome) {
+      return Arrays.asList(OUTCOMES).indexOf(outcome);
+    }
+
+    @Override
+    public int getNumOutcomes() {
+      return OUTCOMES.length;
+    }
+  }
+
+  /**
+   * Exact ties: every outcome scores the same at every position, so which candidates
+   * survive truncation and the order of equal winners follow the priority queue alone.
+   * {@link BeamSearch} orders nodes by score only, as {@link Sequence} did, so the
+   * result must stay identical to the reference.
+   */
+  @ParameterizedTest(name = "beam={0}, len={1}, cache={2}")
+  @MethodSource("beamLengthCacheMatrix")
+  void exactTiesKeepTheReferenceOrder(int beam, int length, int cache) {
+    assertTiedModelMatchesReference(new ConstantModel(0.25d, 0.25d, 0.25d, 0.25d),
+        beam, length, cache, "allTied");
+  }
+
+  /** Partial ties: two outcomes share the top score and two trail. */
+  @ParameterizedTest(name = "beam={0}, len={1}, cache={2}")
+  @MethodSource("beamLengthCacheMatrix")
+  void partialTiesKeepTheReferenceOrder(int beam, int length, int cache) {
+    assertTiedModelMatchesReference(new ConstantModel(0.4d, 0.4d, 0.15d, 0.05d),
+        beam, length, cache, "topTied");
+  }
+
+  private static void assertTiedModelMatchesReference(MaxentModel model, int beam,
+      int length, int cache, String name) {
+    int numSequences = 3;
+    String[] input = randomInput(length, 7000L + length);
+    String desc = caseDesc(name, beam, length, cache);
+    Sequence[] expected = referenceBestSequences(numSequences, input, null,
+        new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(numSequences, input, null, new SeededContextGenerator(), ACCEPT_ALL);
+    assertSequencesEqual(expected, actual, desc);
+  }
+
+  @ParameterizedTest(name = "len={0}, cache={1}")
+  @MethodSource("lengthCacheMatrix")
+  void multiWinnerOrderingMatchesReference(int length, int cache) {
+    MaxentModel model = model();
+    int beam = 5;
+    int numSequences = 3;
+    Object[] additionalContext = {"ac-ctx"};
+    String[] input = randomInput(length, 4000L + length);
+    String desc = caseDesc("multiWinner[k=3]", beam, length, cache);
+
+    Sequence[] expected = referenceBestSequences(numSequences, input,
+        additionalContext, new SeededContextGenerator(), ACCEPT_ALL,
+        model, beam, cache);
+    Sequence[] actual = new BeamSearch(beam, model, cache)
+        .bestSequences(numSequences, input, additionalContext,
+            new SeededContextGenerator(), ACCEPT_ALL);
+
+    assertSequencesEqual(expected, actual, desc);
+    if (length > 0) {
+      Assertions.assertEquals(numSequences, actual.length,
+          desc + ": expected a full k-best list");
+      // Winners must come out in non-increasing score order.
+      for (int s = 1; s < actual.length; s++) {
+        Assertions.assertTrue(actual[s - 1].getScore() >= actual[s].getScore(),
+            desc + ": winner order not non-increasing at index " + s);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 5. Concurrency determinism: one shared BeamSearch, 8 worker threads
+  // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // 6. Winner materialization: outcomes, per-position probs and score of the
+  //    winning Sequence are consistent with the model's eval outputs
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "cache={0}")
+  @MethodSource("cacheSizes")
+  void winnerMaterializationMatchesModelOutputs(int cache) {
+    MaxentModel model = model();
+    String[] input = randomInput(7, 6000L);
+    int beam = 3;
+
+    String desc = "materialization[cache=" + cache + "]";
+    BeamSearch bs = new BeamSearch(beam, model, cache);
+    Sequence winner = bs.bestSequence(input, null, new SeededContextGenerator(),
+        ACCEPT_ALL);
+    Assertions.assertNotNull(winner, desc);
+    Assertions.assertEquals(input.length, winner.getSize(), desc + ": size");
+
+    // The winner must equal the reference winner.
+    Sequence refWinner = referenceBestSequences(1, input, null,
+        new SeededContextGenerator(), ACCEPT_ALL, model, beam, cache)[0];
+    Assertions.assertEquals(refWinner.getOutcomes(), winner.getOutcomes(),
+        desc + ": outcomes vs reference");
+
+    // Walk the winning path and recompute the expected probs/score independently.
+    List<String> outcomes = winner.getOutcomes();
+    double[] probs = winner.getProbs();
+    double expectedScore = 0d;
+    SeededContextGenerator cg = new SeededContextGenerator();
+    for (int i = 0; i < outcomes.size(); i++) {
+      String[] prefix = outcomes.subList(0, i).toArray(new String[0]);
+      String[] contexts = cg.getContext(i, input, prefix, new Object[0]);
+      double[] eval = model.eval(contexts);
+      int outcomeIndex = model.getIndex(outcomes.get(i));
+      Assertions.assertTrue(outcomeIndex >= 0, desc + ": outcome known to model");
+      double expectedProb = eval[outcomeIndex];
+
+      assertBitIdentical(expectedProb, probs[i], desc + ": getProbs()[" + i + "]");
+      assertBitIdentical(expectedProb, winner.getProb(i),
+          desc + ": getProb(" + i + ")");
+      expectedScore += StrictMath.log(expectedProb);
+    }
+    assertBitIdentical(expectedScore, winner.getScore(), desc + ": score");
+  }
+}

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/BeamSearchTest.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/BeamSearchTest.java
@@ -17,6 +17,7 @@
 
 package opennlp.tools.ml;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +44,6 @@ public class BeamSearchTest {
       return new String[] {outcomeSequence[index]};
     }
   }
-
 
   static class IdentityModel implements MaxentModel {
 
@@ -134,10 +134,123 @@ public class BeamSearchTest {
   }
 
   /**
+   * Uniform model: every outcome is equally probable in every context, so all
+   * candidates at a given depth tie on score exactly.
+   */
+  static class UniformModel implements MaxentModel {
+
+    private final String[] outcomes;
+
+    UniformModel(String[] outcomes) {
+      this.outcomes = outcomes;
+    }
+
+    public double[] eval(String[] context) {
+      double[] probs = new double[outcomes.length];
+      Arrays.fill(probs, 1.0d / outcomes.length);
+      return probs;
+    }
+
+    public double[] eval(String[] context, double[] probs) {
+      Arrays.fill(probs, 1.0d / outcomes.length);
+      return probs;
+    }
+
+    public double[] eval(String[] context, float[] values) {
+      return eval(context);
+    }
+
+    public String getAllOutcomes(double[] outcomes) {
+      return null;
+    }
+
+    public String getBestOutcome(double[] outcomes) {
+      return null;
+    }
+
+    public int getIndex(String outcome) {
+      return 0;
+    }
+
+    public int getNumOutcomes() {
+      return outcomes.length;
+    }
+
+    public String getOutcome(int i) {
+      return outcomes[i];
+    }
+  }
+
+  /**
+   * A two-outcome model that follows the first context feature and, like a trained
+   * model, writes its scores into the caller's buffer.
+   */
+  static class ContextModel implements MaxentModel {
+
+    private static final String[] OUTCOMES = {"a", "b"};
+
+    public double[] eval(String[] context) {
+      return eval(context, new double[2]);
+    }
+
+    public double[] eval(String[] context, double[] probs) {
+      boolean first = "x".equals(context[0]);
+      probs[0] = first ? 0.9d : 0.1d;
+      probs[1] = first ? 0.1d : 0.9d;
+      return probs;
+    }
+
+    public double[] eval(String[] context, float[] values) {
+      return eval(context);
+    }
+
+    public String getAllOutcomes(double[] outcomes) {
+      return null;
+    }
+
+    public String getBestOutcome(double[] outcomes) {
+      return null;
+    }
+
+    public int getIndex(String outcome) {
+      return Arrays.asList(OUTCOMES).indexOf(outcome);
+    }
+
+    public int getNumOutcomes() {
+      return OUTCOMES.length;
+    }
+
+    public String getOutcome(int i) {
+      return OUTCOMES[i];
+    }
+  }
+
+  /**
+   * Tests that a cached score array is not overwritten by a later evaluation into the
+   * shared buffer: the third token reuses the first token's context instance, so it
+   * hits the cache and must still see the scores of that context.
+   */
+  @Test
+  void testCachedScoresSurviveLaterEvaluations() {
+    String[] sequence = {"x", "y", "x"};
+    String[] contextX = {"x"};
+    String[] contextY = {"y"};
+    BeamSearchContextGenerator<String> cg = (index, seq, priorDecisions, additionalContext) ->
+        "x".equals(seq[index]) ? contextX : contextY;
+
+    Sequence best = new BeamSearch(1, new ContextModel(), 64)
+        .bestSequence(sequence, null, cg, (i, seq, outcomes, outcome) -> true);
+
+    Assertions.assertEquals(Arrays.asList("a", "b", "a"), best.getOutcomes());
+    Assertions.assertEquals(0.9d, best.getProbs()[2], 0d);
+  }
+
+  /**
    * Tests finding a sequence of length one.
    */
   @Test
   void testBestSequenceOneElementInput() {
+
     String[] sequence = {"1"};
     BeamSearchContextGenerator<String> cg = new IdentityFeatureGenerator(sequence);
 

--- a/opennlp-tools/src/test/java/opennlp/tools/ml/SeededMaxentModel.java
+++ b/opennlp-tools/src/test/java/opennlp/tools/ml/SeededMaxentModel.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package opennlp.tools.ml;
+
+import opennlp.tools.ml.model.MaxentModel;
+
+/**
+ * A deterministic pseudo-random {@link MaxentModel} test fixture. The probability of an
+ * outcome is derived from a hash of the joined context strings, the outcome index and a
+ * fixed seed with splitmix64-style mixing, so repeated evals of the same context return
+ * identical values in (0.01, 0.99]. Values are intentionally not normalized. The
+ * {@code eval(context, probs)} buffer contract is honored: values are written into the
+ * passed array and that same array is returned. Stateless and therefore thread-safe.
+ */
+class SeededMaxentModel implements MaxentModel {
+
+  private final String[] outcomes;
+  private final long seed;
+
+  /**
+   * Initializes a {@link SeededMaxentModel} instance.
+   *
+   * @param outcomes The outcome labels; the outcome index is the array index.
+   * @param seed The seed all probabilities are derived from.
+   */
+  SeededMaxentModel(String[] outcomes, long seed) {
+    this.outcomes = outcomes;
+    this.seed = seed;
+  }
+
+  /**
+   * @return A pseudo-random probability in (0.01, 0.99], a pure function
+   *         of {@code context}, {@code outcomeIndex} and the seed.
+   */
+  private double prob(String[] context, int outcomeIndex) {
+    long h = seed;
+    for (String c : context) {
+      h = mix(h, c.hashCode());
+    }
+    h = mix(h, outcomeIndex);
+    // splitmix64 finalizer for avalanche
+    h ^= h >>> 30;
+    h *= 0xBF58476D1CE4E5B9L;
+    h ^= h >>> 27;
+    h *= 0x94D049BB133111EBL;
+    h ^= h >>> 31;
+    double u = (h >>> 11) * (1.0 / (1L << 53)); // [0, 1)
+    return 0.01 + 0.98 * u; // (0.01, 0.99]
+  }
+
+  /**
+   * @return {@code h} combined with {@code v} FNV-style.
+   */
+  private static long mix(long h, long v) {
+    return (h ^ (v + 0x9E3779B97F4A7C15L)) * 0x100000001B3L;
+  }
+
+  @Override
+  public double[] eval(String[] context) {
+    return eval(context, new double[outcomes.length]);
+  }
+
+  @Override
+  public double[] eval(String[] context, double[] probs) {
+    for (int i = 0; i < outcomes.length; i++) {
+      probs[i] = prob(context, i);
+    }
+    return probs; // buffer contract: write into the passed array AND return it
+  }
+
+  @Override
+  public double[] eval(String[] context, float[] values) {
+    return eval(context);
+  }
+
+  @Override
+  public String getOutcome(int i) {
+    return outcomes[i];
+  }
+
+  @Override
+  public int getNumOutcomes() {
+    return outcomes.length;
+  }
+
+  @Override
+  public String getAllOutcomes(double[] outcomes) {
+    return null;
+  }
+
+  @Override
+  public String getBestOutcome(double[] outcomes) {
+    return null;
+  }
+
+  @Override
+  public int getIndex(String outcome) {
+    for (int i = 0; i < outcomes.length; i++) {
+      if (outcomes[i].equals(outcome)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}


### PR DESCRIPTION
Backport of #1205 (OPENNLP-1903) to opennlp-2.x.

## Problem

`BeamSearch.bestSequences` performs O(beamSize × numOutcomes × n²) element copies per document (object count is O(beam × numOutcomes × n)):

1. Every candidate expansion (`new Sequence(top, out, p)`) copies the parent's entire `outcomes` and `probs` lists (`Sequence.java`).
2. Every pop copies them again via `Sequence.getOutcomes()` (`List.copyOf`, added in OPENNLP-1340) followed by `toArray()`.

For a 215-token chunk with beam 3 and 3 outcomes that is ~550k element copies per document per model. This churn is invisible single-threaded but saturates memory write bandwidth under concurrency: throughput plateaus at ~5.8x on a 24-core run regardless of offered concurrency (12 vs 32 threads yield the same docs/s), and splitting work across independent processes degrades per-core efficiency by ~55%, the contended resource is below the process (the memory bus), not any lock (lock profiling shows zero contention; GC pauses are ~2 ms).

The copying dates to the original 2010 beam-search import; OPENNLP-1340 (2023) added the `List.copyOf` on top. It only becomes a *scaling* ceiling now that OPENNLP-1816 makes shared ME instances across threads practical.

## Fix

Replace the per-candidate `Sequence` copies with a private immutable `SearchNode` chain inside `bestSequences`:

- Child expansion becomes O(1) (parent link + outcome + prob instead of copying two lists).
- The outcome array for context generation is built from the chain when needed; `outcomes()` allocates a fresh array on each call.
- Only the winning sequences are converted to public `Sequence` objects, via `Sequence.add` which accumulates `score += StrictMath.log(p)` in the same order, bit-identical scores.
- `compareTo` mirrors `Sequence.compareTo` exactly (score only), so `PriorityQueue` behavior is unchanged, ties included.

No public API changes; one file changed in production code (`BeamSearch.java`, +80/−13).

## Correctness evidence

`BeamSearchEquivalenceTest` ports the pre-refactor algorithm inline as a reference and asserts bit-identical behavior (outcome order, scores, per-position probs via `doubleToRawLongBits`):

- 372 seeded combinations: 5 beam sizes × 6 input lengths × 2 cache settings, tight `minSequenceScore` thresholds, restrictive validators (including the `next.isEmpty()` fallback and reject-everything), k-best winner ordering.
- Existing suites green: `BeamSearchTest`, namefind / postag / chunker / lemmatizer (112 tests).

## Performance evidence

`BeamSearchBenchmark` (JMH, synthetic deterministic model, isolates the sequence mechanics; only public API, so the same class runs against both implementations, baseline = pre-refactor jar):

| sequenceLength | pre 24T | post 24T | ratio |
|---------------:|--------:|---------:|------:|
| 8 | 1.40M ops/s | 3.16M ops/s | 2.3x |
| 64 | 67.5k ops/s | 297k ops/s | 4.4x |
| 256 | 5,491 ops/s | 50,176 ops/s | 9.1x |

Pre-refactor scaling on 24 threads collapses with sequence length (6.2x to 2.5x); post-refactor scaling grows (7.0x to 11.5x).

Real-model measurements (`NameFinderME`, en-ner-person, shared instance, 1.3 KB docs):

- 24 pinned x86 cores: saturation throughput 5,609 to 12,304 docs/s (+119%); plateau knee moves from ~12 threads to ~20+.
- 8 pinned x86 cores: 8-thread scaling 4.69x to 7.05x.
- 4-core ARM (Pi 5): allocation per document −59%, saturated throughput ~2x (435 to 864 docs/s).
- Single-thread is roughly neutral on x86 (−2…−4%) and ~+27% on ARM.

Full methodology and the JMH table are in #1205; the numbers there were taken on main.


## Backport notes

- 2.x has no per-call search state (OPENNLP-1816 is 3.0 only), so `BeamSearch` stays as thread-unsafe as before and the concurrent equivalence test is not carried over. The cache now stores copies of the eval scores instead of the shared `probs` buffer, as on main.
- On main, `SearchNode.compareTo` breaks exact score ties by outcome chain. On 2.x it orders by score alone, exactly as `Sequence.compareTo` did: `NameFinderMETest` has a real exact tie where the canonical order changes the returned span, and a patch release should not change output. The tie-break test stays on main.
- Two tests added for the 2.x-specific parts: `exactTiesKeepTheReferenceOrder` and `partialTiesKeepTheReferenceOrder` run the equivalence matrix with constant-distribution models, so tied candidates are checked against the `Sequence`-based reference, and `testCachedScoresSurviveLaterEvaluations` pins the cache copy (it fails on `opennlp-2.x` before this change with `[a, b, b]`).
- Full `opennlp-tools` suite: 1,854 tests, 0 failures.
