### PR TITLE
[2.x] Pin checkstyle to 12.3.1, the 13+ line requires Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,8 @@
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
-							<version>14.0.0</version>
+							<!-- 12.x is the last line that runs on Java 17; 13+ needs Java 21. -->
+							<version>12.3.1</version>
 						</dependency>
 					</dependencies>
 					<executions>


### PR DESCRIPTION
This fixes the build break caused by an incompatibility between checkstyle 14.0.0 and the Java 17 builds of `opennlp-2.x`.

Checkstyle 13+ is compiled for Java 21, so since #1256 every build of this branch fails at `validate` with `UnsupportedClassVersionError` on Java 17, and on Java 21 and 25 with Javadoc parse errors in untouched files. Same bump as #1243, same revert as #1246: back to 12.3.1, the last line that runs on Java 17.

To stop it coming back, the dependabot ignore for `com.puppycrawl.tools:*` on `main` (which targets this branch) needs `version-update:semver-major` added; that is a separate one-line PR on `main`.

Unblocks #1252, #1259, #1260, #1261, #1262.
