### PR TITLE
Cancel superseded pull request CI runs

### DIFF
--- a/.github/workflows/allowlist-check.yml
+++ b/.github/workflows/allowlist-check.yml
@@ -32,6 +32,13 @@ on:
     paths:
       - ".github/**"
 
+concurrency:
+  # A new commit on a pull request makes the run in flight obsolete, so cancel it
+  # instead of paying for a result nobody will read. Pushes to a branch group by ref
+  # and are never cancelled, so every commit on main keeps a full build.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,13 @@ on:
     branches:
       - main
 
+concurrency:
+  # A new commit on a pull request makes the run in flight obsolete, so cancel it
+  # instead of paying for a result nobody will read. Pushes to a branch group by ref
+  # and are never cancelled, so every commit on main keeps a full build.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Pushing a new commit to a PR currently leaves the run already in flight to finish. Nobody reads that result — the newer commit supersedes it — but it still occupies runners to completion.

`Java CI` runs **nine jobs per run**: a 3 OS × 2 JDK build matrix (`fail-fast: false`) plus three shell-test jobs, and macOS and Windows runners bill at a multiple of Linux. So a superseded run is not a rounding error.

### How often this happens

Sampling the last 100 `maven.yml` pull_request runs (52 branches), **9 had a newer commit arrive while they were still running** — ~9%. Median PR run is ~11 minutes of wall-clock across those nine jobs. Branches with the most, unsurprisingly, are the ones under active review.

### The change

Both workflows that react to `pull_request` get:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

### What is deliberately *not* cancelled

- **Pushes to `main`.** They fall to the `github.ref` group and `cancel-in-progress` evaluates to `false`, so every commit on main still gets a full build. Cancelling those would leave commits without a result and could interfere with `Regenerate NOTICE` and `Publish snapshot artifacts`.
- **`license.yml` and `publish-snapshots.yml`** are untouched — both are push-to-`main`-only, and `license.yml` commits back to the repo, so cancelling it mid-run is exactly what we don't want. (Serialising snapshot publishes with `cancel-in-progress: false` might be worth a separate look, but it is a different problem from this one.)

### Note on the required status check

`ASF Allowlist Check` is a required check via `.asf.yaml`. Cancellation only ever hits runs for *superseded* commits; the run for the head commit always completes and reports. So the required check keeps behaving as before.

`concurrency` is a core Actions feature, not an action reference, so the ASF allowlist doesn't apply to it.