### PR TITLE
OPENNLP-1925: Document RegEx exemption and harden ReDoS guard test

### DIFF
--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/namefind/RegexNameFinder.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/namefind/RegexNameFinder.java
@@ -29,6 +29,9 @@ import opennlp.tools.util.Span;
 
 /**
  * A {@link TokenNameFinder} implementation based on a series of regular expressions.
+ * <p>
+ * Please note: RegEx is not allowed in the processing path of OpenNLP.
+ * However, a RegEx step is an obvious exception.
  */
 public final class RegexNameFinder implements TokenNameFinder {
 

--- a/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/namefind/RegexNameFinderFactory.java
+++ b/opennlp-core/opennlp-runtime/src/main/java/opennlp/tools/namefind/RegexNameFinderFactory.java
@@ -26,6 +26,9 @@ import java.util.regex.Pattern;
  *
  * Returns a {@link RegexNameFinder} based on a selection of
  * defaults or a configuration and a selection of defaults.
+ * <p>
+ * Please note: RegEx is not allowed in the processing path of OpenNLP.
+ * However, a RegEx step is an obvious exception.
  */
 public class RegexNameFinderFactory {
 

--- a/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/namefind/RegexNameFinderFactoryTest.java
+++ b/opennlp-core/opennlp-runtime/src/test/java/opennlp/tools/namefind/RegexNameFinderFactoryTest.java
@@ -20,10 +20,15 @@ package opennlp.tools.namefind;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import opennlp.tools.tokenize.WhitespaceTokenizer;
 import opennlp.tools.util.Span;
@@ -95,24 +100,32 @@ public class RegexNameFinderFactoryTest {
    * Crafted inputs that used to drive the built-in EMAIL and URL patterns into
    * catastrophic backtracking / deep recursion (ReDoS, CWE-1333 / CWE-400 / CWE-674).
    * The hardened patterns must finish quickly regardless of input length.
+   * <p>
+   * Each attack runs as its own test so a regression names the exact input that
+   * got slow. Each case does one warmup run outside the timed section, so the
+   * budget measures the match itself rather than JVM cold start on throttled
+   * machines.
    */
-  @Test
-  void testBuiltinPatternsAreNotVulnerableToReDoS() {
-    final String emailLocalBlowup = "a".repeat(100_000) + "@ ";
-    final String emailDomainBlowup = "x@a" + "-a".repeat(60_000) + " ";
-    final String urlPathRecursion = "http://a.com/" + "a".repeat(100_000) + " ";
-    final String urlNestedBlowup = "http://a.com" + "/a".repeat(50_000) + "%z";
-    // The reported StackOverflowError repro: a long ?a&a&a&... query string, which
-    // drove the nested (&(...)+ ... )* group in the old URL pattern into deep recursion.
-    final String urlQueryRecursion = "http://a.com/p?a" + "&a".repeat(50_000) + "= ";
+  private static Stream<Arguments> reDoSAttacks() {
+    return Stream.of(
+        Arguments.of(Named.of("emailLocalBlowup", "a".repeat(100_000) + "@ ")),
+        Arguments.of(Named.of("emailDomainBlowup", "x@a" + "-a".repeat(60_000) + " ")),
+        Arguments.of(Named.of("urlPathRecursion", "http://a.com/" + "a".repeat(100_000) + " ")),
+        Arguments.of(Named.of("urlNestedBlowup", "http://a.com" + "/a".repeat(50_000) + "%z")),
+        // The reported StackOverflowError repro: a long ?a&a&a&... query string, which
+        // drove the nested (&(...)+ ... )* group in the old URL pattern into deep recursion.
+        Arguments.of(Named.of("urlQueryRecursion", "http://a.com/p?a" + "&a".repeat(50_000) + "= ")));
+  }
 
-    Assertions.assertTimeoutPreemptively(Duration.ofSeconds(2), () -> {
-      for (String attack : new String[] {
-          emailLocalBlowup, emailDomainBlowup, urlPathRecursion, urlNestedBlowup, urlQueryRecursion}) {
-        String[] tokens = WhitespaceTokenizer.INSTANCE.tokenize(attack);
-        regexNameFinder.find(tokens);
-      }
-    });
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("reDoSAttacks")
+  void testBuiltinPatternsAreNotVulnerableToReDoS(String attack) {
+    String[] tokens = WhitespaceTokenizer.INSTANCE.tokenize(attack);
+    // Warmup: JIT-compile the pattern engine before the timed run.
+    regexNameFinder.find(tokens);
+
+    Assertions.assertTimeoutPreemptively(Duration.ofSeconds(2),
+        () -> regexNameFinder.find(tokens));
   }
 
   /**


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/OPENNLP-1925

Two changes, both in `opennlp-core/opennlp-runtime`, no runtime behavior change:

**1. Document the RegEx exemption.** OpenNLP's processing path is RegEx-free by policy. `RegexNameFinder` and `RegexNameFinderFactory` are the deliberate exception since their entire purpose is regular-expression matching. The class Javadoc of both now states: "RegEx is not allowed in the processing path of OpenNLP. However, a RegEx step is an obvious exception."

**2. Harden `testBuiltinPatternsAreNotVulnerableToReDoS`** (added in OPENNLP-1922). The single test ran all five attack inputs inside one 2-second wall-clock budget. On a throttled or cold CI executor, JVM warmup alone can consume the budget before the match itself runs (observed in an eval build: 2.372s against the 2.0s budget on a workload that takes 30ms warm), and a failure did not name the input that got slow. Each attack now runs as its own parameterized case with one warmup pass outside the timed section. The 2-second budget per case acts purely as a hang guard; against the pre-OPENNLP-1922 patterns the warmup pass itself hangs or overflows the stack, so the test still goes red on a regression.

Benchmark evidence (this branch, and main, since the regex code is identical):

| Workload | Old patterns | Hardened patterns |
| --- | --- | --- |
| Attack suite, all five inputs | hang (>10s) or StackOverflowError per input | 30ms total, slowest ~10ms |
| Normal text scan, EMAIL, 1MB | 131ms | 25ms |
| Normal text scan, URL, 1MB | 18ms | 15ms |